### PR TITLE
[Fix/57] 장소 리스트 제목 20자 초과 시 에러메세지 반환

### DIFF
--- a/app/(lobby)/places/(without-pattern)/create/page.tsx
+++ b/app/(lobby)/places/(without-pattern)/create/page.tsx
@@ -33,6 +33,11 @@ export default function CreatePlace() {
       return;
     }
 
+    if (title.length > 20) {
+      setError({ type: 'FIELD', message: '리스트 제목은 20자 이내여야 합니다.' });
+      return;
+    }
+
     try {
       const listId = await createPlaceList({
         title: title,
@@ -72,6 +77,7 @@ export default function CreatePlace() {
             onChange={(e) => setTitle(e.target.value)}
             id='title'
             className='create-place-input'
+            maxLength={20}
           />
           {error && error.type === 'FIELD' && (
             <p className='text-typo-description text-tag-red-text -mt-1'>{error.message}</p>

--- a/lib/actions/placeList.ts
+++ b/lib/actions/placeList.ts
@@ -25,6 +25,7 @@ export const createNewPlaceList = async ({ title, icon, description }: CreatePla
     throw new Error('인증 정보가 없습니다.');
   }
   if (!title.trim()) throw new Error('리스트 제목을 입력해주세요.');
+  if (title.length > 20) throw new Error('리스트 제목은 20자 이내여야 합니다.');
 
   const supabase = await supabaseAdmin;
 


### PR DESCRIPTION
## 🛠️ 과제 요약

- 장소 리스트 생성 시 제목 20자 초과하면 에러메세지 반환

<img width="300" alt="스크린샷 2026-06-24 오후 11 49 45" src="https://github.com/user-attachments/assets/e6ef46dc-9e09-4157-9cb9-d12e6fd1fa99" />


## 📝 요구 사항과 구현 내용

#### 1️⃣ 클라이언트 글자수 제한 처리 
- 제목 input 속성에 maxLength 추가
- 제출 시 20자 제한 validation 처리 추가

#### 2️⃣ 서버 액션 글자수 제한 처리
- 서버 액션에서도 20자 제한 후 에러 반환 

## 🔗 연관된 이슈
- close #57 