### PR TITLE
[Feat/41] 공용 드래그 스크롤 훅 구현

### DIFF
--- a/app/(lobby)/places/(without-pattern)/create/page.tsx
+++ b/app/(lobby)/places/(without-pattern)/create/page.tsx
@@ -63,7 +63,7 @@ export default function CreatePlace() {
         </button>
       </header>
 
-      <form className='flex flex-col gap-4'>
+      <div className='flex flex-col gap-4'>
         <div className='flex flex-col gap-3'>
           <label
             htmlFor='title'
@@ -153,7 +153,7 @@ export default function CreatePlace() {
             className='resize-none create-place-input'
           />
         </div>
-      </form>
+      </div>
       {error && error.type === 'UPLOAD' && (
         <p className='text-typo-description text-tag-red-text -mt-1'>{error.message}</p>
       )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -216,3 +216,15 @@ input:-webkit-autofill:active {
     #f4f4f5
   );
 }
+
+@layer utilities {
+  .no-scrollbar {
+    -ms-overflow-style: none; /* 인터넷 익스플로러 */
+    scrollbar-width: none; /* 파이어폭스 */
+  }
+
+  /* 크롬, 사파리, 엣지 */
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -217,14 +217,12 @@ input:-webkit-autofill:active {
   );
 }
 
-@layer utilities {
-  .no-scrollbar {
-    -ms-overflow-style: none; /* 인터넷 익스플로러 */
-    scrollbar-width: none; /* 파이어폭스 */
-  }
+@utility no-scrollbar {
+  -ms-overflow-style: none; /* 인터넷 익스플로러 */
+  scrollbar-width: none; /* 파이어폭스 */
 
   /* 크롬, 사파리, 엣지 */
-  .no-scrollbar::-webkit-scrollbar {
+  &::-webkit-scrollbar {
     display: none;
   }
 }

--- a/components/features/Place/TagList.tsx
+++ b/components/features/Place/TagList.tsx
@@ -4,10 +4,12 @@ import { Icon } from '@/components/common/Icon';
 import TagListItem from './TagListItem';
 import { useState } from 'react';
 import { useGetPlaceListTags } from '@/hooks/place-list/useGetPlaceListDetail';
+import { useDragScroll } from '@/hooks/useDragScroll';
 
 // 장소 리스트에 포함된 태그를 보여주는 태그 리스트 컴포넌트(상단에 위치)
 export default function TagList({ listId }: { listId: string }) {
   const { data } = useGetPlaceListTags(listId);
+  const { ref, ...dragHandler } = useDragScroll<HTMLDivElement>();
   const [activeIds, setActiveIds] = useState<string[]>([]);
 
   const handleToggleTag = (id: string) => {
@@ -23,7 +25,11 @@ export default function TagList({ listId }: { listId: string }) {
           size={18}
         />
       </button>
-      <div className='flex gap-2 overflow-x-scroll flex-1 items-center'>
+      <div
+        ref={ref}
+        {...dragHandler}
+        className='flex gap-2 overflow-x-scroll flex-1 items-center no-scrollbar'
+      >
         {data.map((item) => (
           <TagListItem
             key={item.id}

--- a/hooks/useDragScroll.ts
+++ b/hooks/useDragScroll.ts
@@ -40,11 +40,23 @@ export const useDragScroll = <T extends HTMLElement>() => {
       // 이동 거리를 계속 업데이트
       const dist = x - startX.current;
       moveX.current = dist; // 임계값에 현재 위치 저장(클릭 방지)
-      el.scrollLeft = scrollLeft.current - (x - startX.current);
+      el.scrollLeft = scrollLeft.current - dist;
+    };
+
+    // 마우스 휠 이벤트 추가
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      // 휠 세로 이동량 계산 - 휠 내리면 오른쪽 스크롤, 휠 올리면 왼쪽 스크롤
+      el.scrollLeft += e.deltaY;
     };
 
     el.addEventListener('mousemove', handleMouseMove, { passive: false });
-    return () => el.removeEventListener('mousemove', handleMouseMove);
+    el.addEventListener('wheel', handleWheel, { passive: false });
+
+    return () => {
+      el.removeEventListener('mousemove', handleMouseMove);
+      el.removeEventListener('wheel', handleWheel);
+    };
   }, []);
 
   const onClick = useCallback((e: React.MouseEvent) => {

--- a/hooks/useDragScroll.ts
+++ b/hooks/useDragScroll.ts
@@ -1,0 +1,65 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+
+export const useDragScroll = <T extends HTMLElement>() => {
+  const ref = useRef<T>(null);
+  const isDragging = useRef<boolean>(false);
+  const startX = useRef(0);
+  const scrollLeft = useRef(0);
+  const moveX = useRef(0); // 이동 임계값 처리용
+
+  // 마우스로 클릭 시작
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    // 현재 클릭된 값이 없으면 중단
+    if (!ref.current) return;
+    // 클릭된 값이 있으면 드래그 시작 위치 저장(좌측에서 시작)
+    isDragging.current = true;
+    moveX.current = 0; // 드래그 시작할 때마다 임계값 초기화
+    startX.current = e.pageX - ref.current.offsetLeft;
+    scrollLeft.current = ref.current.scrollLeft;
+
+    // 드래그중임을 표시하기 위해 스타일 지정
+    ref.current.style.cursor = 'grabbing';
+    ref.current.style.userSelect = 'none';
+  }, []);
+
+  const stopDrag = useCallback(() => {
+    isDragging.current = false;
+    if (!ref.current) return;
+    ref.current.style.cursor = 'grab';
+    ref.current.style.removeProperty('user-select');
+  }, []);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      e.preventDefault();
+      const x = e.pageX - el.offsetLeft;
+      // 이동 거리를 계속 업데이트
+      const dist = x - startX.current;
+      moveX.current = dist; // 임계값에 현재 위치 저장(클릭 방지)
+      el.scrollLeft = scrollLeft.current - (x - startX.current);
+    };
+
+    el.addEventListener('mousemove', handleMouseMove, { passive: false });
+    return () => el.removeEventListener('mousemove', handleMouseMove);
+  }, []);
+
+  const onClick = useCallback((e: React.MouseEvent) => {
+    // 5px 이상 움직였다면(드래그중이면) 클릭 무시
+    if (Math.abs(moveX.current) > 5) {
+      e.stopPropagation();
+    }
+  }, []);
+
+  return {
+    ref,
+    onMouseDown,
+    onMouseUp: stopDrag, // 드래그 종료 감지
+    onMouseLeave: stopDrag, // 마우스가 컴포넌트 밖으로 나가면 드래그 종료
+    onClick,
+    style: { cursor: 'grab' }, // 기본 커서를 손 모양으로 설정
+  };
+};


### PR DESCRIPTION
## 🛠️ 과제 요약

- 윈도우에서도 드래그 스크롤이 가능하게 하는 훅 구현

## 📝 요구 사항과 구현 내용

#### 1️⃣ 드래그 스크롤 훅 구현(`useDragScroll.ts`)
- `onMouseDown`: 드래그 시작 시 적용되는 함수
- `stopDrag`: 마우스 뗐을 때, 기준 HTML 요소를 벗어났을 때 드래그를 취소하는 함수
- useEffect 안 `handleMouseMove`: 스크롤중일 때 거리 계산하는 함수
  - Next.js에서 합성 이벤트는 내부적으로 passive: true로 등록되는데, passive:true면 preventDefault()가 동작하지 않습니다. 따라서 passive:false 처리를 하고, DOM에 안전하게 접근하기 위해서 마운트 이후 시점에 이벤트를 등록하기 위해 useEffect 안에 구현하였습니다.
- `onClick`: 드래그가 끝났을 때 안쪽 요소가 클릭되는 것을 최대한 방지하기 위해, 이동 임계값(`moveX`)이 5px 이상일 경우 클릭 무시

#### 2️⃣ 기본 스크롤바 스타일 제거 (`gobals.css`)
- 기본적으로 적용되어 있는 스크롤 바 스타일 제거
- 브라우저별로 기본 적용되어 있는 스크롤 바 스타일 제거

#### 3️⃣ 자잘한 버그 수정: 장소 리스트 생성 시 불필요한 폼 제거
- 엔터키 누를 시 페이지 전체 새로고침 방지하기 위해 form 태그를 div 태그로 수정
- 저장하기 버튼을 눌러야만 리스트 생성이 가능하기 때문에 form 불필요

## 💬 PR 포인트 & 궁금한 점
- 맥에서는 일단 되지만 윈도우 테스트가 필요합니다... 사용해보시고 문제 있으면 말씀해주세요
- 현재 태그 리스트에만 적용되어 있습니다. 임의값 추가해서 테스트가 어려우시면 구글 아이디 알려드리겠습니다!
- 다른 곳에 적용해보고 싶으시면 사용하는 쪽에서
    ```typescript
    const { ref, ...dragHandler } = useDragScroll<HTMLDivElement>(); // 타입 지정해주셔야 작동합니다
    ```
    요렇게 사용해주세요

## 🔗 연관된 이슈
- close #41 
