### PR TITLE
[Feat/47]클라이언트 조회 요청 구조 리팩토리 및 api생성

### DIFF
--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -8,6 +8,7 @@ import {
 import PlaceListHeader from '@/components/features/Place/PlaceListHeader';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import PlaceListPlaces from '@/components/features/Place/PlaceListPlaces';
+import { prefetchPlaceListDetail } from '@/lib/actions/prefetch/prefetchPlaceListDetail';
 
 export default async function PlaceListDetail({ params }: { params: Promise<{ listId: string }> }) {
   const { listId } = await params;
@@ -20,11 +21,7 @@ export default async function PlaceListDetail({ params }: { params: Promise<{ li
     },
   });
 
-  await Promise.all([
-    queryClient.prefetchQuery(placeListDetailQueryOptions(listId)),
-    queryClient.prefetchInfiniteQuery(placeListPlacesQueryOptions(listId)),
-    queryClient.prefetchQuery(placeListTagsQueryOptions(listId)),
-  ]);
+  await prefetchPlaceListDetail(queryClient, listId);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/app/(lobby)/places/(with-pattern)/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/page.tsx
@@ -6,7 +6,14 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 import Link from 'next/link';
 
 export default async function Page() {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        // prefetch한 데이터를 클라이언트에서 즉시 다시 fetch하는 걸 방지
+        staleTime: 60 * 1000, // 1분
+      },
+    },
+  });
   await prefetchPlaceList(queryClient);
 
   return (

--- a/app/(lobby)/places/(with-pattern)/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/page.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@/components/common/Icon';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import PlaceList from '@/components/features/Place/PlaceList';
-import { prefetchPlaceList } from '@/lib/actions/prefetchPlaceList';
+import { prefetchPlaceList } from '@/lib/actions/prefetch/prefetchPlaceList';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import Link from 'next/link';
 

--- a/app/(lobby)/places/(with-pattern)/search/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/search/page.tsx
@@ -1,4 +1,7 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import CoreSearchResultList from '@/components/features/search/CoreSearchResultList';
+import { prefetchPlaceSearch } from '@/lib/actions/prefetchPlaceSearch';
 
 interface CoreSearchPageProps {
   searchParams: Promise<{ query: string }>;
@@ -6,16 +9,23 @@ interface CoreSearchPageProps {
 
 export default async function CoreSearchPage({ searchParams }: CoreSearchPageProps) {
   const resolvedSearchParams = await searchParams;
-  const keyword = resolvedSearchParams.query;
+  const keyword = resolvedSearchParams.query?.trim();
 
   // 검색 페이지 url에 직접 접근할 때를 대비하여 작성
   if (!keyword) {
     return <div>검색어를 입력해주세요.</div>;
   }
 
+  const queryClient = new QueryClient();
+  await prefetchPlaceSearch(queryClient, keyword);
+
   return (
     <div className='w-full flex flex-col'>
-      <CoreSearchResultList keyword={keyword} />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <QueryBoundary>
+          <CoreSearchResultList keyword={keyword} />
+        </QueryBoundary>
+      </HydrationBoundary>
     </div>
   );
 }

--- a/app/(lobby)/places/(with-pattern)/search/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/search/page.tsx
@@ -16,7 +16,13 @@ export default async function CoreSearchPage({ searchParams }: CoreSearchPagePro
     return <div>검색어를 입력해주세요.</div>;
   }
 
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30 * 1000,
+      },
+    },
+  });
   await prefetchPlaceSearch(queryClient, keyword);
 
   return (

--- a/app/(lobby)/places/(with-pattern)/search/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/search/page.tsx
@@ -1,7 +1,7 @@
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import CoreSearchResultList from '@/components/features/search/CoreSearchResultList';
-import { prefetchPlaceSearch } from '@/lib/actions/prefetchPlaceSearch';
+import { prefetchPlaceSearch } from '@/lib/actions/prefetch/prefetchPlaceSearch';
 
 interface CoreSearchPageProps {
   searchParams: Promise<{ query: string }>;

--- a/app/api/view/place-list/[listId]/places/route.ts
+++ b/app/api/view/place-list/[listId]/places/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseUser } from '@/lib/utils/supabase';
+import { getPlaceListPlaces } from '@/lib/api/placeList';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ listId: string }> }
+) {
+  const { listId } = await params;
+  const searchParams = request.nextUrl.searchParams;
+  const createdAt = searchParams.get('createdAt');
+  const cursorId = searchParams.get('id');
+
+  const supabase = await supabaseUser();
+
+  try {
+    const data = await getPlaceListPlaces({
+      supabase,
+      listId,
+      cursor: createdAt && cursorId ? { createdAt, id: cursorId } : null,
+    });
+    return NextResponse.json(data);
+  } catch (error: any) {
+    console.error('❌ place-list places 에러:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/api/view/place-list/route.ts
+++ b/app/api/view/place-list/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseUser } from '@/lib/utils/supabase';
-import { getAllPlaceLists } from '@/lib/api/placeList'; // 순수 함수로 분리한 버전
+import { getAllPlaceLists } from '@/lib/api/placeList'; 
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;

--- a/app/api/view/place-list/route.ts
+++ b/app/api/view/place-list/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseUser } from '@/lib/utils/supabase';
+import { getAllPlaceLists } from '@/lib/api/placeList'; // 순수 함수로 분리한 버전
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const listType = searchParams.get('listType') as 'owned' | 'shared';
+  const offset = Number(searchParams.get('offset') ?? 0);
+
+  const supabase = await supabaseUser();
+
+  try {
+    const data = await getAllPlaceLists({ supabase, listType, offset });
+    return NextResponse.json(data);
+  } catch (error: any) {
+    console.error('❌ place-list 에러:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/api/view/search/auto-complete/route.ts
+++ b/app/api/view/search/auto-complete/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseUser } from '@/lib/utils/supabase';
+import { getAutoCompletePlaces } from '@/lib/api/placeSearch';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const query = searchParams.get('query') ?? '';
+  const limit = Number(searchParams.get('limit') ?? 5);
+
+  const supabase = await supabaseUser();
+
+  try {
+    const data = await getAutoCompletePlaces({ supabase, query, limit });
+    return NextResponse.json(data);
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/api/view/search/route.ts
+++ b/app/api/view/search/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseUser } from '@/lib/utils/supabase';
+import { getPlaceSearchResults } from '@/lib/api/placeSearch';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const query = searchParams.get('query') ?? '';
+  const limit = Number(searchParams.get('limit') ?? 10);
+  const offset = Number(searchParams.get('offset') ?? 0);
+
+  const supabase = await supabaseUser();
+
+  try {
+    const data = await getPlaceSearchResults({ supabase, query, limit, offset });
+    return NextResponse.json(data);
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/components/features/search/CorePlaceSearchResultItem.tsx
+++ b/components/features/search/CorePlaceSearchResultItem.tsx
@@ -12,8 +12,6 @@ const getCategoryLabel = (category: CorePlaceSearchResult['category']) => {
 export default function CorePlaceSearchResultItem({ result }: CorePlaceSearchResultItemProps) {
   const categoryLabel = getCategoryLabel(result.category);
 
-  console.log('result', result);
-
   return (
     <div className='flex flex-col gap-1 p-3 border border-brand-gray-300 rounded-sm bg-brand-gray-0 hover:bg-brand-gray-50 transition-colors'>
       <div className='flex items-center justify-between'>

--- a/components/features/search/CorePlaceSearchResultItem.tsx
+++ b/components/features/search/CorePlaceSearchResultItem.tsx
@@ -12,6 +12,8 @@ const getCategoryLabel = (category: CorePlaceSearchResult['category']) => {
 export default function CorePlaceSearchResultItem({ result }: CorePlaceSearchResultItemProps) {
   const categoryLabel = getCategoryLabel(result.category);
 
+  console.log('result', result);
+
   return (
     <div className='flex flex-col gap-1 p-3 border border-brand-gray-300 rounded-sm bg-brand-gray-0 hover:bg-brand-gray-50 transition-colors'>
       <div className='flex items-center justify-between'>

--- a/components/features/search/CoreSearchResultList.tsx
+++ b/components/features/search/CoreSearchResultList.tsx
@@ -22,7 +22,7 @@ export default function CoreSearchResultList({ keyword }: SearchResultListProps)
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage && !isFetchNextPageError) {
           fetchNextPage();
         }
       },
@@ -31,7 +31,7 @@ export default function CoreSearchResultList({ keyword }: SearchResultListProps)
 
     observer.observe(target);
     return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [hasNextPage, isFetchingNextPage, isFetchNextPageError, fetchNextPage]);
 
   const camelCaseItems = toCamelKey<PlaceSearchResults>(data);
   const items = camelCaseItems.items;
@@ -48,11 +48,17 @@ export default function CoreSearchResultList({ keyword }: SearchResultListProps)
             />
           ))}
           {isFetchNextPageError && (
-            <div className='text-typo-description text-tag-red-text text-center py-3'>
-              추가 결과를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+            <div className='flex flex-col items-center gap-2 py-3'>
+              <p className='text-typo-description text-tag-red-text'>추가 결과를 불러오지 못했습니다.</p>
+              <button
+                onClick={() => fetchNextPage()}
+                className='text-typo-description text-brand-blue-600 underline'
+              >
+                다시 시도하기
+              </button>
             </div>
           )}
-          <div ref={observerTargetRef} />
+          {!isFetchNextPageError && <div ref={observerTargetRef} />}
         </>
       )}
       <RegisterNewPlaceBanner keyword={keyword} />

--- a/components/features/search/CoreSearchResultList.tsx
+++ b/components/features/search/CoreSearchResultList.tsx
@@ -3,6 +3,8 @@
 import CorePlaceSearchResultItem from '@/components/features/search/CorePlaceSearchResultItem';
 import RegisterNewPlaceBanner from '@/components/features/search/RegisterNewPlaceBanner';
 import { useSearchPlaces } from '@/hooks/place-search/useSearchPlaces';
+import { toCamelKey } from '@/lib/utils/toCamelCase';
+import { PlaceSearchResults } from '@/types/CorePlace';
 import { useEffect, useRef } from 'react';
 
 interface SearchResultListProps {
@@ -10,7 +12,7 @@ interface SearchResultListProps {
 }
 
 export default function CoreSearchResultList({ keyword }: SearchResultListProps) {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useSearchPlaces(keyword);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } = useSearchPlaces(keyword);
   const observerTargetRef = useRef<HTMLDivElement>(null);
 
   // 리스트 바닥 근처에 도달하면 다음 페이지(offset)를 불러옴
@@ -31,13 +33,8 @@ export default function CoreSearchResultList({ keyword }: SearchResultListProps)
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const items = data?.items ?? [];
-
-  // 첫 결과를 기다리는 중에는 결과/배너 UI를 보여주지 않음
-  // TODO: 추후 스피너로 교체
-  if (isLoading) {
-    return <div className='text-typo-description text-brand-gray-400'>Loading...</div>;
-  }
+  const camelCaseItems = toCamelKey<PlaceSearchResults>(data);
+  const items = camelCaseItems.items;
 
   return (
     <div className='flex flex-col gap-3'>
@@ -50,6 +47,11 @@ export default function CoreSearchResultList({ keyword }: SearchResultListProps)
               result={item}
             />
           ))}
+          {isFetchNextPageError && (
+            <div className='text-typo-description text-tag-red-text text-center py-3'>
+              추가 결과를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+            </div>
+          )}
           <div ref={observerTargetRef} />
         </>
       )}

--- a/components/features/search/GooglePlaceDetail.tsx
+++ b/components/features/search/GooglePlaceDetail.tsx
@@ -9,8 +9,6 @@ interface Props {
 }
 
 export default function GooglePlaceDetail({ place, addNewPlace, onClose }: Props) {
-  console.log(place);
-
   const getBusinessStatus = (status?: string) => {
     switch (status) {
       case 'OPERATIONAL':

--- a/hooks/place-list/useGetAllPlaceLists.ts
+++ b/hooks/place-list/useGetAllPlaceLists.ts
@@ -1,11 +1,24 @@
-import { getAllPlaceLists } from '@/lib/actions/placeList';
+
 import { AllPlaceLists, ListType } from '@/types/placeList';
 import { useSuspenseInfiniteQuery, UseSuspenseInfiniteQueryResult } from '@tanstack/react-query';
+
+const fetchAllPlaceLists = async ({
+  listType,
+  offset = 0,
+}: {
+  listType: ListType;
+  offset?: number;
+}): Promise<AllPlaceLists> => {
+  const params = new URLSearchParams({ listType, offset: String(offset) });
+  const res = await fetch(`/api/view/place-list?${params.toString()}`);
+  if (!res.ok) throw new Error('장소 리스트를 가져오는 데 실패했습니다.');
+  return res.json();
+};
 
 export const useGetAllPlaceLists = (listType: ListType): UseSuspenseInfiniteQueryResult<AllPlaceLists, Error> => {
   const query = useSuspenseInfiniteQuery({
     queryKey: ['place-list', listType],
-    queryFn: ({ pageParam = 0 }) => getAllPlaceLists({ listType, offset: pageParam }),
+    queryFn: ({ pageParam = 0 }) => fetchAllPlaceLists({ listType, offset: pageParam }),
     // 더보기 버튼 클릭 시 다음 호출의 pageParam(offset) 계산
     getNextPageParam: (lastPage, allPages) => {
       const loaded = allPages.reduce((sum, p) => sum + p.items.length, 0);

--- a/hooks/place-list/useGetPlaceListDetail.ts
+++ b/hooks/place-list/useGetPlaceListDetail.ts
@@ -1,5 +1,5 @@
 import { getPlaceListDetail, getPlaceListPlaces, getPlaceListTags } from '@/lib/actions/placeList';
-import { PageParam } from '@/types/placeList';
+import { PageParam, Place } from '@/types/placeList';
 import { infiniteQueryOptions, queryOptions, useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 // queryOptions 정의 - 서버/클라이언트 캐시 동기화를 위해
@@ -11,11 +11,22 @@ export const placeListDetailQueryOptions = (listId: string) => {
   });
 };
 
+const fetchPlaceListPlaces = async (listId: string, cursor: PageParam): Promise<Place[]> => {
+  const params = new URLSearchParams();
+  if (cursor) {
+    params.set('createdAt', cursor.createdAt);
+    params.set('id', cursor.id);
+  }
+  const res = await fetch(`/api/view/place-list/${listId}/places?${params.toString()}`);
+  if (!res.ok) throw new Error('저장된 장소를 가져오는 데 실패했습니다.');
+  return res.json();
+};
+
 // 리스트에 저장된 장소 queryOptions
 export const placeListPlacesQueryOptions = (listId: string) => {
   return infiniteQueryOptions({
     queryKey: ['place-list', listId, 'places'],
-    queryFn: ({ pageParam }) => getPlaceListPlaces(listId, pageParam),
+    queryFn: ({ pageParam }) => fetchPlaceListPlaces(listId, pageParam),
     initialPageParam: null as PageParam,
     getNextPageParam: (lastPage) =>
       lastPage.length < 20 ? undefined : { createdAt: lastPage.at(-1)!.createdAt, id: lastPage.at(-1)!.id },

--- a/hooks/place-list/useGetPlaceListDetail.ts
+++ b/hooks/place-list/useGetPlaceListDetail.ts
@@ -1,4 +1,4 @@
-import { getPlaceListDetail, getPlaceListPlaces, getPlaceListTags } from '@/lib/actions/placeList';
+import { getPlaceListDetail, getPlaceListTags } from '@/lib/actions/placeList';
 import { PageParam, Place } from '@/types/placeList';
 import { infiniteQueryOptions, queryOptions, useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 

--- a/hooks/place-search/useAutoCompleteSearch.ts
+++ b/hooks/place-search/useAutoCompleteSearch.ts
@@ -1,19 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
-import { getAutoCompletePlaces } from '@/lib/actions/places';
+import type { AutoCompleteResults } from '@/types/CorePlace';
+
+interface FetchAutoCompleteProps {
+  query: string;
+  limit?: number;
+}
+
+const fetchAutoComplete = async ({ query, limit = 5 }: FetchAutoCompleteProps): Promise<AutoCompleteResults> => {
+  const params = new URLSearchParams({ query, limit: String(limit) });
+  const res = await fetch(`/api/view/search/auto-complete?${params.toString()}`);
+
+  if (!res.ok) throw new Error('자동완성 결과를 가져오는 데 실패했습니다.');
+  return res.json();
+};
 
 export const useAutoCompleteSearch = (query: string) => {
   const trimmedQuery = query.trim();
 
   return useQuery({
-    // 검색어가 바뀔 때마다 별도의 캐시 엔트리로 관리됨
-    // 같은 검색어로 다시 들어오면(예: 지웠다가 다시 입력) 캐시된 결과를 즉시 사용
     queryKey: ['autoCompletePlaces', trimmedQuery],
-    queryFn: () => getAutoCompletePlaces({ query: trimmedQuery }),
-    // 빈 문자열일 때는 요청 자체를 보내지 않음
+    queryFn: () => fetchAutoComplete({ query: trimmedQuery }),
     enabled: trimmedQuery.length > 0,
-    // 같은 검색어에 대해 일정 시간 내 재요청 시 네트워크 호출 없이 캐시 사용
     staleTime: 1000 * 60,
-    // 자동완성 결과는 길게 들고 있을 필요가 없으므로 짧게 유지
     gcTime: 1000 * 60 * 5,
   });
 };

--- a/hooks/place-search/useSearchPlaces.ts
+++ b/hooks/place-search/useSearchPlaces.ts
@@ -1,13 +1,30 @@
 import { useInfiniteQuery, type UseInfiniteQueryResult } from '@tanstack/react-query';
-import { getPlaceSearchResults } from '@/lib/actions/places';
-import { PlaceSearchResults } from '@/types/CorePlace';
+import type { PlaceSearchResults } from '@/types/CorePlace';
+
+interface FetchPlaceSearchProps {
+  query: string;
+  limit?: number;
+  offset?: number;
+}
+
+const fetchPlaceSearch = async ({
+  query,
+  limit = 10,
+  offset = 0,
+}: FetchPlaceSearchProps): Promise<PlaceSearchResults> => {
+  const params = new URLSearchParams({ query, limit: String(limit), offset: String(offset) });
+  const res = await fetch(`/api/view/search?${params.toString()}`);
+
+  if (!res.ok) throw new Error('검색 결과를 가져오는 데 실패했습니다.');
+  return res.json();
+};
 
 export const useSearchPlaces = (query: string): UseInfiniteQueryResult<PlaceSearchResults, Error> => {
   const trimmedQuery = query.trim();
 
   return useInfiniteQuery({
     queryKey: ['place-search', trimmedQuery],
-    queryFn: ({ pageParam = 0 }) => getPlaceSearchResults({ query: trimmedQuery, offset: pageParam }),
+    queryFn: ({ pageParam = 0 }) => fetchPlaceSearch({ query: trimmedQuery, offset: pageParam }),
     // 검색어가 비어있으면 요청 자체를 보내지 않음
     enabled: trimmedQuery.length > 0,
     // 더보기(바닥 도달) 시 다음 호출의 pageParam(offset) 계산

--- a/hooks/place-search/useSearchPlaces.ts
+++ b/hooks/place-search/useSearchPlaces.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, type UseInfiniteQueryResult } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery, type UseSuspenseInfiniteQueryResult } from '@tanstack/react-query';
 import type { PlaceSearchResults } from '@/types/CorePlace';
 
 interface FetchPlaceSearchProps {
@@ -19,15 +19,12 @@ const fetchPlaceSearch = async ({
   return res.json();
 };
 
-export const useSearchPlaces = (query: string): UseInfiniteQueryResult<PlaceSearchResults, Error> => {
+export const useSearchPlaces = (query: string): UseSuspenseInfiniteQueryResult<PlaceSearchResults, Error> => {
   const trimmedQuery = query.trim();
 
-  return useInfiniteQuery({
+  const result = useSuspenseInfiniteQuery({
     queryKey: ['place-search', trimmedQuery],
     queryFn: ({ pageParam = 0 }) => fetchPlaceSearch({ query: trimmedQuery, offset: pageParam }),
-    // 검색어가 비어있으면 요청 자체를 보내지 않음
-    enabled: trimmedQuery.length > 0,
-    // 더보기(바닥 도달) 시 다음 호출의 pageParam(offset) 계산
     getNextPageParam: (lastPage, allPages) => {
       const loaded = allPages.reduce((sum, p) => sum + p.items.length, 0);
       return loaded < lastPage.totalCount ? loaded : undefined;
@@ -38,4 +35,11 @@ export const useSearchPlaces = (query: string): UseInfiniteQueryResult<PlaceSear
       totalCount: data.pages[0]?.totalCount ?? 0,
     }),
   });
+
+  // 더보기(자동 스크롤) 에러는 컴포넌트 내부에서 처리, 그 외는 ErrorBoundary로 전파
+  if (result.error && !result.isFetching && !result.isFetchNextPageError) {
+    throw result.error;
+  }
+
+  return result;
 };

--- a/lib/actions/placeList.ts
+++ b/lib/actions/placeList.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { AllPlaceLists, ListType, PageParam, Place, PlaceListDetail, Tag } from '@/types/placeList';
+import { PageParam, Place, PlaceListDetail, Tag } from '@/types/placeList';
 import { auth } from '../utils/auth';
 import { supabaseAdmin } from '../utils/supabase';
 import { toCamelKey } from '../utils/toCamelCase';
@@ -9,12 +9,6 @@ export interface CreatePlaceListForm {
   title: string;
   icon?: string;
   description?: string;
-}
-
-interface getAllPlaceListProps {
-  listType: ListType;
-  limit?: number;
-  offset: number;
 }
 
 // 장소 리스트 생성
@@ -42,30 +36,7 @@ export const createNewPlaceList = async ({ title, icon, description }: CreatePla
   return data;
 };
 
-// 전체 장소 리스트 조회
-export const getAllPlaceLists = async ({
-  listType,
-  limit = 10,
-  offset,
-}: getAllPlaceListProps): Promise<AllPlaceLists> => {
-  // 인증 확인
-  const session = await auth();
-  if (!session?.user?.id) {
-    throw new Error('인증 정보가 없습니다.');
-  }
 
-  const supabase = await supabaseAdmin;
-  const { data, error } = await supabase.rpc('get_all_place_list', {
-    p_user_id: session.user.id,
-    p_type: listType,
-    p_limit: limit,
-    p_offset: offset,
-  });
-
-  if (error) throw error;
-  if (!data) throw new Error('장소 리스트를 가져오는 데 실패했습니다.');
-  return toCamelKey<AllPlaceLists>(data);
-};
 
 // 장소 리스트 상세 개요
 export const getPlaceListDetail = async (listId: string): Promise<PlaceListDetail> => {

--- a/lib/actions/places.ts
+++ b/lib/actions/places.ts
@@ -3,8 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { supabaseAdmin } from '@/lib/utils/supabase/index';
 import { auth } from '@/lib/utils/auth';
-import type { AutoCompleteResults, CreatePlacePayload, PlaceSearchResult, PlaceSearchResults } from '@/types/CorePlace';
-import { toCamelKey } from '../utils/toCamelCase';
+import type { CreatePlacePayload } from '@/types/CorePlace';
 
 // 이미 등록한 장소인지 체크
 export async function checkPlaceExists(googlePlaceId: string) {
@@ -66,64 +65,3 @@ export async function createNewPlace(payload: CreatePlacePayload): Promise<Creat
 
   return { success: true, placeId };
 }
-
-interface GetAutoCompletePlacesProps {
-  query: string;
-  limit?: number;
-}
-
-export const getAutoCompletePlaces = async ({
-  query,
-  limit = 5,
-}: GetAutoCompletePlacesProps): Promise<AutoCompleteResults> => {
-  // 인증 확인
-  const session = await auth();
-  if (!session?.user?.id) {
-    throw new Error('인증 정보가 없습니다.');
-  }
-
-  const trimmedQuery = query.trim();
-  if (trimmedQuery === '') return { items: [] };
-
-  const supabase = await supabaseAdmin;
-  const { data, error } = await supabase.rpc('search_places_autocomplete', {
-    p_query: trimmedQuery,
-    p_limit: limit,
-  });
-
-  if (error) throw error;
-  if (!data) throw new Error('자동완성 결과를 가져오는 데 실패했습니다.');
-  return toCamelKey<AutoCompleteResults>(data);
-};
-
-interface GetPlaceSearchResultsProps {
-  query: string;
-  limit?: number;
-  offset?: number;
-}
-
-export const getPlaceSearchResults = async ({
-  query,
-  limit = 10,
-  offset = 0,
-}: GetPlaceSearchResultsProps): Promise<PlaceSearchResults> => {
-  // 인증 확인
-  const session = await auth();
-  if (!session?.user?.id) {
-    throw new Error('인증 정보가 없습니다.');
-  }
-
-  const trimmedQuery = query.trim();
-  if (trimmedQuery === '') return { items: [], totalCount: 0 };
-
-  const supabase = await supabaseAdmin;
-  const { data, error } = await supabase.rpc('search_places', {
-    p_query: trimmedQuery,
-    p_limit: limit,
-    p_offset: offset,
-  });
-
-  if (error) throw error;
-  if (!data) throw new Error('검색 결과를 가져오는 데 실패했습니다.');
-  return toCamelKey<PlaceSearchResults>(data);
-};

--- a/lib/actions/prefetch/prefetchPlaceList.ts
+++ b/lib/actions/prefetch/prefetchPlaceList.ts
@@ -18,5 +18,3 @@ export async function prefetchPlaceList(queryClient: QueryClient) {
     }),
   ]);
 }
-
-

--- a/lib/actions/prefetch/prefetchPlaceList.ts
+++ b/lib/actions/prefetch/prefetchPlaceList.ts
@@ -1,17 +1,22 @@
 import { QueryClient } from '@tanstack/react-query';
-import { getAllPlaceLists } from './placeList';
+import { getAllPlaceLists } from '@/lib/api/placeList';
+import { supabaseUser }from '@/lib/utils/supabase';
 
 export async function prefetchPlaceList(queryClient: QueryClient) {
+  const supabase = await supabaseUser();
+
   await Promise.all([
     queryClient.prefetchInfiniteQuery({
       queryKey: ['place-list', 'owned'],
-      queryFn: ({ pageParam = 0 }) => getAllPlaceLists({ listType: 'owned', offset: pageParam }),
+      queryFn: ({ pageParam = 0 }) => getAllPlaceLists({ supabase, listType: 'owned', offset: pageParam }),
       initialPageParam: 0,
     }),
     queryClient.prefetchInfiniteQuery({
       queryKey: ['place-list', 'shared'],
-      queryFn: ({ pageParam = 0 }) => getAllPlaceLists({ listType: 'shared', offset: pageParam }),
+      queryFn: ({ pageParam = 0 }) => getAllPlaceLists({ supabase, listType: 'shared', offset: pageParam }),
       initialPageParam: 0,
     }),
   ]);
 }
+
+

--- a/lib/actions/prefetch/prefetchPlaceListDetail.ts
+++ b/lib/actions/prefetch/prefetchPlaceListDetail.ts
@@ -1,7 +1,7 @@
     
 import { QueryClient } from '@tanstack/react-query';
 import { supabaseUser } from '@/lib/utils/supabase';
-import { getPlaceListPlaces } from '@/lib/api/placeList'; // 이전에 분리한 순수 함수
+import { getPlaceListPlaces } from '@/lib/api/placeList';
 import type { PageParam } from '@/types/placeList';
 import { placeListDetailQueryOptions, placeListTagsQueryOptions } from '@/hooks/place-list/useGetPlaceListDetail';
 

--- a/lib/actions/prefetch/prefetchPlaceListDetail.ts
+++ b/lib/actions/prefetch/prefetchPlaceListDetail.ts
@@ -1,0 +1,22 @@
+    
+import { QueryClient } from '@tanstack/react-query';
+import { supabaseUser } from '@/lib/utils/supabase';
+import { getPlaceListPlaces } from '@/lib/api/placeList'; // 이전에 분리한 순수 함수
+import type { PageParam } from '@/types/placeList';
+import { placeListDetailQueryOptions, placeListTagsQueryOptions } from '@/hooks/place-list/useGetPlaceListDetail';
+
+export async function prefetchPlaceListDetail(queryClient: QueryClient, listId: string) {
+  const supabase = await supabaseUser();
+
+  await Promise.all([
+    queryClient.prefetchQuery(placeListDetailQueryOptions(listId)),
+    queryClient.prefetchInfiniteQuery({
+      queryKey: ['place-list', listId, 'places'],
+      // queryFn만 서버 직접 호출로 오버라이드
+      queryFn: ({ pageParam }) =>
+        getPlaceListPlaces({ supabase, listId, cursor: pageParam as PageParam }),
+      initialPageParam: null as PageParam,
+    }),
+    queryClient.prefetchQuery(placeListTagsQueryOptions(listId)),
+  ]);
+}

--- a/lib/actions/prefetch/prefetchPlaceListDetail.ts
+++ b/lib/actions/prefetch/prefetchPlaceListDetail.ts
@@ -3,7 +3,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { supabaseUser } from '@/lib/utils/supabase';
 import { getPlaceListPlaces } from '@/lib/api/placeList';
 import type { PageParam } from '@/types/placeList';
-import { placeListDetailQueryOptions, placeListTagsQueryOptions } from '@/hooks/place-list/useGetPlaceListDetail';
+import { placeListDetailQueryOptions, placeListPlacesQueryOptions, placeListTagsQueryOptions } from '@/hooks/place-list/useGetPlaceListDetail';
 
 export async function prefetchPlaceListDetail(queryClient: QueryClient, listId: string) {
   const supabase = await supabaseUser();
@@ -11,7 +11,7 @@ export async function prefetchPlaceListDetail(queryClient: QueryClient, listId: 
   await Promise.all([
     queryClient.prefetchQuery(placeListDetailQueryOptions(listId)),
     queryClient.prefetchInfiniteQuery({
-      queryKey: ['place-list', listId, 'places'],
+         ...placeListPlacesQueryOptions(listId),
       // queryFn만 서버 직접 호출로 오버라이드
       queryFn: ({ pageParam }) =>
         getPlaceListPlaces({ supabase, listId, cursor: pageParam as PageParam }),

--- a/lib/actions/prefetch/prefetchPlaceSearch.ts
+++ b/lib/actions/prefetch/prefetchPlaceSearch.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
 import { supabaseUser } from '@/lib/utils/supabase';
-import { getPlaceSearchResults } from '../api/placeSearch';
+import { getPlaceSearchResults } from '../../api/placeSearch';
 
 export async function prefetchPlaceSearch(queryClient: QueryClient, query: string) {
   const supabase = await supabaseUser();

--- a/lib/actions/prefetchPlaceSearch.ts
+++ b/lib/actions/prefetchPlaceSearch.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from '@tanstack/react-query';
+import { supabaseUser } from '@/lib/utils/supabase';
+import { getPlaceSearchResults } from '../api/placeSearch';
+
+export async function prefetchPlaceSearch(queryClient: QueryClient, query: string) {
+  const supabase = await supabaseUser();
+
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: ['place-search', query],
+    queryFn: ({ pageParam = 0 }) => getPlaceSearchResults({ supabase, query, offset: pageParam }),
+    initialPageParam: 0,
+  });
+}

--- a/lib/api/placeList.ts
+++ b/lib/api/placeList.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { toCamelKey } from '@/lib/utils/toCamelCase';
+import type { Place, PageParam, AllPlaceLists, ListType } from '@/types/placeList';
+
+interface GetPlaceListPlacesProps {
+  supabase: SupabaseClient;
+  listId: string;
+  cursor?: PageParam;
+}
+
+export const getPlaceListPlaces = async ({
+  supabase,
+  listId,
+  cursor = null,
+}: GetPlaceListPlacesProps): Promise<Place[]> => {
+  const { data, error } = await supabase.rpc('get_place_list_places', {
+    p_list_id: listId,
+    p_cursor_created_at: cursor?.createdAt ?? null,
+    p_cursor_id: cursor?.id ?? null,
+    p_limit: 20,
+  });
+
+  if (error) throw error;
+  if (!data) throw new Error('저장된 장소를 가져오는 데 실패했습니다.');
+  return toCamelKey<Place[]>(data);
+};
+
+interface getAllPlaceListProps {
+  listType: ListType;
+  limit?: number;
+  offset: number;
+}
+
+// 전체 장소 리스트 조회
+export const getAllPlaceLists = async ({
+  supabase,
+  listType,
+  limit = 10,
+  offset,
+}: getAllPlaceListProps & { supabase: SupabaseClient }): Promise<AllPlaceLists> => {
+  const { data, error } = await supabase.rpc('get_all_place_list', {
+    p_type: listType,
+    p_limit: limit,
+    p_offset: offset,
+  });
+
+  if (error) throw error;
+  if (!data) throw new Error('장소 리스트를 가져오는 데 실패했습니다.');
+  return toCamelKey<AllPlaceLists>(data);
+};

--- a/lib/api/placeSearch.ts
+++ b/lib/api/placeSearch.ts
@@ -1,0 +1,53 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { AutoCompleteResults, PlaceSearchResults } from '@/types/CorePlace';
+
+interface GetAutoCompletePlacesProps {
+  supabase: SupabaseClient;
+  query: string;
+  limit?: number;
+}
+
+export const getAutoCompletePlaces = async ({
+  supabase,
+  query,
+  limit = 5,
+}: GetAutoCompletePlacesProps): Promise<AutoCompleteResults> => {
+  const trimmedQuery = query.trim();
+  if (trimmedQuery === '') return { items: [] };
+
+  const { data, error } = await supabase.rpc('search_places_autocomplete', {
+    p_query: trimmedQuery,
+    p_limit: limit,
+  });
+
+  if (error) throw error;
+  if (!data) throw new Error('자동완성 결과를 가져오는 데 실패했습니다.');
+  return data as AutoCompleteResults;
+};
+
+interface GetPlaceSearchResultsProps {
+  supabase: SupabaseClient;
+  query: string;
+  limit?: number;
+  offset?: number;
+}
+
+export const getPlaceSearchResults = async ({
+  supabase,
+  query,
+  limit = 10,
+  offset = 0,
+}: GetPlaceSearchResultsProps): Promise<PlaceSearchResults> => {
+  const trimmedQuery = query.trim();
+  if (trimmedQuery === '') return { items: [], totalCount: 0 };
+
+  const { data, error } = await supabase.rpc('search_places', {
+    p_query: trimmedQuery,
+    p_limit: limit,
+    p_offset: offset,
+  });
+
+  if (error) throw error;
+  if (!data) throw new Error('검색 결과를 가져오는 데 실패했습니다.');
+  return data as PlaceSearchResults;
+};

--- a/lib/utils/supabase/client.ts
+++ b/lib/utils/supabase/client.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { createClient } from '@supabase/supabase-js';
+import { useSession } from 'next-auth/react';
+import { useMemo } from 'react';
+
+// 클라이언트에서 직접 supabase를 사용할 때, accessToken을 세션에서 가져와서 설정하는 함수
+export const supabaseBrowser = () => {
+  const { data: session } = useSession();
+
+  return useMemo(() => {
+    return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+      accessToken: async () => session?.supabaseAccessToken ?? null,
+    });
+  }, [session?.supabaseAccessToken]);
+};


### PR DESCRIPTION
## 🛠️ 과제 요약

기존에 `supabaseAdmin`(서비스 롤 키)으로 처리하던 조회 로직을 인증된 유저 권한(`supabaseUser()`) 기반으로 전환하고, 클라이언트의 무한스크롤 재요청을 조회 서버액션을 Route Handler를 경유하는 구조로 개선했습니다.

## 📝 요구 사항과 구현 내용

### 1️⃣ 클라이언트 조회 구조 설계 결정

클라이언트에서 조회시 **Next.js Route Handler 경유 방식**을 적용했습니다.

채택 이유:
- RLS 정책이 "공개 API 스펙"처럼 클라이언트에 노출되는 것을 방지
- 비즈니스 룰(페이지 크기 제한, 필드 가공 등)을 서버 코드에서 명시적으로 통제 가능
- 기존 NextAuth + `supabaseUser()` 기반 인증 흐름과 완전히 일관되게 유지

```
[서버] 초기 prefetch
  → supabaseUser() 직접 호출 (Route Handler ❌ )
  → HydrationBoundary로 클라이언트에 전달

[클라이언트] 이후 fetchNextPage (무한스크롤)
  → Route Handler fetch
  → Route Handler 내부에서 supabaseUser() 호출
```

### 2️⃣ 리스트 조회 API 생성 (`/api/view/place-list`)

**전체 장소 리스트 조회** (`GET /api/view/place-list`)
- `listType`(`owned`/`shared`), `offset` 쿼리 파라미터 수신
- `supabaseUser()`로 인증된 요청으로 `get_all_place_list` function 호출
- 기존 `supabaseAdmin` + `p_user_id` 수동 전달 방식 → `auth.uid()` 기반 `SECURITY INVOKER`로 함수 수정

**장소 상세 페이지 places 조회** (`GET /api/view/place-list/[listId]/places`)
- cursor 기반 페이지네이션 (`createdAt`, `id` 쿼리 파라미터)
- `supabaseUser()`로 인증된 요청으로 `get_place_list_places` function 호출

### 3️⃣ 검색결과 조회 API 생성 (`/api/view/search`)

**장소 검색** (`GET /api/view/search`)
- offset 기반 무한스크롤 페이지네이션

**자동완성** (`GET /api/view/search/autocomplete`)
- 타이핑마다 가벼운 호출, 별도 엔드포인트로 분리

### 4️⃣ prefetch 함수 구조 개선

`lib/actions/prefetch/` 폴더로 prefetch 함수들을 분리하여 관리합니다.

- `prefetchPlaceList.ts` — 전체 장소 리스트 (owned/shared 병렬 prefetch)
- `prefetchPlaceListDetail.ts` — 장소 리스트 상세 (detail/places/tags 병렬 prefetch)
- `prefetchPlaceSearch.ts` — 장소 검색 결과

서버 prefetch는 Route Handler를 거치지 않고 `lib/api/`의 순수 함수를 `supabaseUser()`와 함께 직접 호출합니다 — 서버가 자기 자신의 Route Handler를 fetch하는 불필요한 네트워크 홉을 방지합니다.

### 5️⃣ `lib/api/` 순수 함수 분리

`supabase` 클라이언트를 인자로 받는 순수 함수로 분리하여, 서버 prefetch와 Route Handler 양쪽에서 재사용할 수 있도록 구성했습니다.

```
lib/api/placeList.ts     getAllPlaceLists, getPlaceListPlaces
lib/api/placeSearch.ts   getPlaceSearchResults, getAutoCompletePlaces
```

---

## 💬 PR 포인트

### 1️⃣ prefetch와 클라이언트 queryFn의 queryKey 일치

prefetch 시 `queryKey`가 클라이언트 `queryOptions`의 `queryKey`와 정확히 일치해야 HydrationBoundary를 통한 캐시 hydration이 제대로 동작합니다. `placeListPlacesQueryOptions`처럼 places prefetch만 `queryFn`을 오버라이드하는 경우에도 `queryKey`는 동일하게 유지했습니다.

### 2️⃣ staleTime 설정

```typescript
const queryClient = new QueryClient({
  defaultOptions: {
    queries: { staleTime: 60 * 1000 }
  }
});
```

기본 staleTime이 0이면 prefetch된 데이터가 hydrate 직후 즉시 stale로 판단되어 클라이언트에서 중복 요청이 발생합니다. `useSuspenseInfiniteQuery`의 경우 이 시점에 Suspense fallback이 다시 발동할 수 있어 prefetch의 이점이 사라집니다.

### 3️⃣ 🧪 테스트 방법

- `/places` 진입 시 네트워크 탭에서 `/api/view/place-list` 요청 없이 초기 렌더 확인 (prefetch로 처리)
- 더보기 버튼 또는 스크롤 하단 도달 시 `/api/view/place-list` GET 요청 발생 확인
- `/places/search?query=검색어` 진입 시 동일하게 초기 렌더는 prefetch, 추가 페이지 로드 시 `/api/view/search` 요청 확인
- `/places/[listId]` 진입 시 places 추가 로드 시 `/api/view/place-list/[listId]/places` 요청 확인

---
## 🔗 연관된 이슈

- close #54 