### PR TITLE
[Feat, Bug] 수정용 링크 생성 및 참여 기능 구현 / 계정 간 데이터 혼재 버그 해결

### DIFF
--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -1,10 +1,5 @@
 import TagList from '@/components/features/Place/TagList';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
-import {
-  placeListDetailQueryOptions,
-  placeListPlacesQueryOptions,
-  placeListTagsQueryOptions,
-} from '@/hooks/place-list/useGetPlaceListDetail';
 import PlaceListHeader from '@/components/features/Place/PlaceListHeader';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import PlaceListPlaces from '@/components/features/Place/PlaceListPlaces';

--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -5,6 +5,7 @@ import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import PlaceListPlaces from '@/components/features/Place/PlaceListPlaces';
 import InviteEditorHandler from '@/components/features/invite/InviteEditorHandler';
 import { prefetchPlaceListDetail } from '@/lib/actions/prefetch/prefetchPlaceListDetail';
+import { Suspense } from 'react';
 
 export default async function PlaceListDetail({ params }: { params: Promise<{ listId: string }> }) {
   const { listId } = await params;
@@ -21,7 +22,12 @@ export default async function PlaceListDetail({ params }: { params: Promise<{ li
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <InviteEditorHandler type='place_list' />
+      <Suspense fallback={null}>
+        <InviteEditorHandler
+          id={listId}
+          type='place_list'
+        />
+      </Suspense>
       <div className='flex flex-col gap-5.5'>
         <QueryBoundary>
           <PlaceListHeader listId={listId} />

--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -8,7 +8,7 @@ import {
 import PlaceListHeader from '@/components/features/Place/PlaceListHeader';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import PlaceListPlaces from '@/components/features/Place/PlaceListPlaces';
-import InviteEditorHandler from '@/components/features/invite/inviteEditorHandler';
+import InviteEditorHandler from '@/components/features/invite/InviteEditorHandler';
 
 export default async function PlaceListDetail({ params }: { params: Promise<{ listId: string }> }) {
   const { listId } = await params;

--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -8,6 +8,7 @@ import {
 import PlaceListHeader from '@/components/features/Place/PlaceListHeader';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import PlaceListPlaces from '@/components/features/Place/PlaceListPlaces';
+import InviteEditorHandler from '@/components/features/invite/inviteEditorHandler';
 
 export default async function PlaceListDetail({ params }: { params: Promise<{ listId: string }> }) {
   const { listId } = await params;
@@ -28,6 +29,7 @@ export default async function PlaceListDetail({ params }: { params: Promise<{ li
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
+      <InviteEditorHandler type='place_list' />
       <div className='flex flex-col gap-5.5'>
         <QueryBoundary>
           <PlaceListHeader listId={listId} />

--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -1,22 +1,16 @@
 import TagList from '@/components/features/Place/TagList';
-import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import PlaceListHeader from '@/components/features/Place/PlaceListHeader';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import PlaceListPlaces from '@/components/features/Place/PlaceListPlaces';
 import InviteEditorHandler from '@/components/features/invite/InviteEditorHandler';
 import { prefetchPlaceListDetail } from '@/lib/actions/prefetch/prefetchPlaceListDetail';
 import { Suspense } from 'react';
+import { getQueryClient } from '@/lib/utils/getQueryClient';
 
 export default async function PlaceListDetail({ params }: { params: Promise<{ listId: string }> }) {
   const { listId } = await params;
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        // prefetch한 데이터를 클라이언트에서 즉시 다시 fetch하는 걸 방지
-        staleTime: 60 * 1000, // 1분
-      },
-    },
-  });
+  const queryClient = getQueryClient();
 
   await prefetchPlaceListDetail(queryClient, listId);
 

--- a/app/(lobby)/places/(with-pattern)/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/page.tsx
@@ -2,18 +2,12 @@ import { Icon } from '@/components/common/Icon';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import PlaceList from '@/components/features/Place/PlaceList';
 import { prefetchPlaceList } from '@/lib/actions/prefetch/prefetchPlaceList';
-import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { getQueryClient } from '@/lib/utils/getQueryClient';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import Link from 'next/link';
 
 export default async function Page() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        // prefetch한 데이터를 클라이언트에서 즉시 다시 fetch하는 걸 방지
-        staleTime: 60 * 1000, // 1분
-      },
-    },
-  });
+  const queryClient = getQueryClient();
   await prefetchPlaceList(queryClient);
 
   return (

--- a/components/common/Dropdown/Item.tsx
+++ b/components/common/Dropdown/Item.tsx
@@ -3,12 +3,14 @@ import { useDropdown } from './DropdownContext';
 interface DropDownItemProps {
   children: React.ReactNode;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
-export default function DropDownItem({ children, onClick }: DropDownItemProps) {
+export default function DropDownItem({ children, onClick, disabled = false }: DropDownItemProps) {
   const { close } = useDropdown();
 
   const handleClick = () => {
+    if (disabled) return;
     close();
     onClick?.();
   };

--- a/components/common/ErrorModal.tsx
+++ b/components/common/ErrorModal.tsx
@@ -10,12 +10,17 @@ interface ErrorModalProps {
 export default function ErrorModal({ title, description, buttonText = '확인' }: ErrorModalProps) {
   const { close } = useModalStore();
   return (
-    <ModalBox width={320}>
+    <ModalBox
+      width={320}
+      isCloseIcon={false}
+    >
       <ModalBox.ModalTitle
         title={title}
-        description={description}
         error={true}
       />
+      <ModalBox.ModalContent>
+        <div className='-mt-1 mb-1'>{description}</div>
+      </ModalBox.ModalContent>
       <ModalBox.ModalBottomContent>
         <button
           className='modal-button bg-tag-red-text text-brand-gray-0'

--- a/components/common/ErrorModal.tsx
+++ b/components/common/ErrorModal.tsx
@@ -1,0 +1,29 @@
+import { useModalStore } from '@/lib/store/modalStore';
+import ModalBox from './Modal/ModalBox';
+
+interface ErrorModalProps {
+  title: string;
+  description: string;
+  buttonText?: string;
+}
+
+export default function ErrorModal({ title, description, buttonText = '확인' }: ErrorModalProps) {
+  const { close } = useModalStore();
+  return (
+    <ModalBox width={320}>
+      <ModalBox.ModalTitle
+        title={title}
+        description={description}
+        error={true}
+      />
+      <ModalBox.ModalBottomContent>
+        <button
+          className='modal-button bg-tag-red-text text-brand-gray-0'
+          onClick={close}
+        >
+          {buttonText}
+        </button>
+      </ModalBox.ModalBottomContent>
+    </ModalBox>
+  );
+}

--- a/components/common/Modal/GlobalModal.tsx
+++ b/components/common/Modal/GlobalModal.tsx
@@ -5,6 +5,7 @@ import EnterInviteLinkModal from '../../features/Plan/EnterInviteLinkModal';
 import CancelSignupModal from '@/components/features/CancelSignupModal';
 import CancelNewPlaceModal from '@/components/features/new-place/CancelNewPlaceModal';
 import ShareLinkModal from '../ShareLinkModal';
+import ErrorModal from '../ErrorModal';
 
 /**
  * 전역 모달 컴포넌트
@@ -31,6 +32,12 @@ export default function GlobalModal() {
         <ShareLinkModal
           type={activeModal.props.type}
           link={activeModal.props.link}
+        />
+      )}
+      {activeModal.type === 'error' && (
+        <ErrorModal
+          title={activeModal.props.title}
+          description={activeModal.props.description}
         />
       )}
     </div>

--- a/components/common/Modal/ModalContent.tsx
+++ b/components/common/Modal/ModalContent.tsx
@@ -3,5 +3,5 @@ interface ModalContentProps {
 }
 
 export default function ModalContent({ children }: ModalContentProps) {
-  return <div className='text-typo-description text-brand-gray-600 text-center'>{children}</div>;
+  return <div className='text-typo-description text-brand-gray-600 text-center whitespace-pre-line'>{children}</div>;
 }

--- a/components/common/Modal/ModalTitle.tsx
+++ b/components/common/Modal/ModalTitle.tsx
@@ -1,12 +1,13 @@
 interface ModalTitleProps {
   title: string;
   description?: string;
+  error?: boolean;
 }
 
-export default function ModalTitle({ title, description }: ModalTitleProps) {
+export default function ModalTitle({ title, description, error = false }: ModalTitleProps) {
   return (
     <div className='flex flex-col gap-0.5 items-center'>
-      <p className='text-typo-sub-title text-brand-blue-700'>{title}</p>
+      <p className={`text-typo-sub-title ${error ? 'text-tag-red-text' : 'text-brand-blue-700'} `}>{title}</p>
       {description && <p className='text-typo-description text-brand-gray-600'>{description}</p>}
     </div>
   );

--- a/components/common/ShareLinkModal.tsx
+++ b/components/common/ShareLinkModal.tsx
@@ -2,6 +2,7 @@
 
 import { Icon } from '@/components/common/Icon';
 import ModalBox from '@/components/common/Modal/ModalBox';
+import { useState } from 'react';
 
 type ShareType = 'VIEW' | 'EDIT';
 
@@ -20,6 +21,21 @@ const MODAL_CONTENT = {
 
 export default function ShareLinkModal({ type, link }: { type: ShareType; link: string }) {
   const modalText = MODAL_CONTENT[type];
+  const [isCopied, setIsCopied] = useState<boolean>(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(link);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (error) {
+      console.error('복사 실패', error);
+      setErrorText('복사에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      setTimeout(() => setErrorText(null), 2000);
+    }
+  };
+
   return (
     <ModalBox width={560}>
       <ModalBox.ModalTitle
@@ -35,13 +51,23 @@ export default function ShareLinkModal({ type, link }: { type: ShareType; link: 
             value={link}
             disabled
           />
-          <button className='modal-button px-5 shrink-0'>
-            <Icon
-              name='Copy'
-              size={16}
-            />{' '}
-            링크 복사
+          <button
+            className='modal-button px-5 shrink-0 min-w-30.25'
+            onClick={handleCopy}
+          >
+            {!isCopied ? (
+              <>
+                <Icon
+                  name='Copy'
+                  size={16}
+                />{' '}
+                링크 복사
+              </>
+            ) : (
+              '복사 성공 !'
+            )}
           </button>
+          {errorText && <div>{errorText}</div>}
         </ModalBox.ModalBottomContent>
       </div>
     </ModalBox>

--- a/components/features/Place/PlaceListDropdwonMenu.tsx
+++ b/components/features/Place/PlaceListDropdwonMenu.tsx
@@ -7,7 +7,7 @@ import { useModalStore } from '@/lib/store/modalStore';
 
 export default function PlaceListDropdownMenu({ id }: { id: string }) {
   const { open } = useModalStore();
-  const { createShareLink } = useShareEditLink();
+  const { createShareLink, isPending } = useShareEditLink();
 
   return (
     <DropDown>
@@ -27,7 +27,12 @@ export default function PlaceListDropdownMenu({ id }: { id: string }) {
         >
           리스트를 보기 위한 링크 보내기
         </DropDown.Item>
-        <DropDown.Item onClick={() => createShareLink(id, 'place_list')}>수정할 수 있도록 초대</DropDown.Item>
+        <DropDown.Item
+          disabled={isPending}
+          onClick={() => createShareLink(id, 'place_list')}
+        >
+          수정할 수 있도록 초대
+        </DropDown.Item>
         <DropDown.Item>공유 옵션 관리</DropDown.Item>
         <DropDown.Item onClick={() => console.log('전체 리스트 편집 페이지로 이동')}>리스트 편집</DropDown.Item>
         <DropDown.Item>리스트 삭제</DropDown.Item>

--- a/components/features/Place/PlaceListDropdwonMenu.tsx
+++ b/components/features/Place/PlaceListDropdwonMenu.tsx
@@ -2,12 +2,12 @@
 
 import DropDown from '@/components/common/Dropdown';
 import { Icon } from '@/components/common/Icon';
-import { useGetOrRefreshEditToken } from '@/hooks/invite-member/useGetOrRefreshEditToken';
+import { useShareEditLink } from '@/hooks/invite-member/useShareEditLink';
 import { useModalStore } from '@/lib/store/modalStore';
 
 export default function PlaceListDropdownMenu({ id }: { id: string }) {
   const { open } = useModalStore();
-  const { mutate: refreshToken } = useGetOrRefreshEditToken();
+  const { createShareLink } = useShareEditLink();
 
   return (
     <DropDown>
@@ -27,21 +27,7 @@ export default function PlaceListDropdownMenu({ id }: { id: string }) {
         >
           리스트를 보기 위한 링크 보내기
         </DropDown.Item>
-        <DropDown.Item
-          onClick={() => {
-            refreshToken(
-              { id, type: 'place_list' },
-              {
-                onSuccess: (token) => {
-                  const editLink = `${process.env.NEXT_PUBLIC_BASE_URL}/places/${id}?invite_token=${token}`;
-                  open({ type: 'shareLink', props: { type: 'EDIT', link: editLink } });
-                },
-              },
-            );
-          }}
-        >
-          수정할 수 있도록 초대
-        </DropDown.Item>
+        <DropDown.Item onClick={() => createShareLink(id, 'place_list')}>수정할 수 있도록 초대</DropDown.Item>
         <DropDown.Item>공유 옵션 관리</DropDown.Item>
         <DropDown.Item onClick={() => console.log('전체 리스트 편집 페이지로 이동')}>리스트 편집</DropDown.Item>
         <DropDown.Item>리스트 삭제</DropDown.Item>

--- a/components/features/Place/PlaceListDropdwonMenu.tsx
+++ b/components/features/Place/PlaceListDropdwonMenu.tsx
@@ -2,10 +2,12 @@
 
 import DropDown from '@/components/common/Dropdown';
 import { Icon } from '@/components/common/Icon';
+import { useGetOrRefreshEditToken } from '@/hooks/invite-member/useGetOrRefreshEditToken';
 import { useModalStore } from '@/lib/store/modalStore';
 
-export default function PlaceListDropdownMenu({ viewLink, editLink }: { viewLink: string; editLink: string }) {
+export default function PlaceListDropdownMenu({ id }: { id: string }) {
   const { open } = useModalStore();
+  const { mutate: refreshToken } = useGetOrRefreshEditToken();
 
   return (
     <DropDown>
@@ -18,10 +20,26 @@ export default function PlaceListDropdownMenu({ viewLink, editLink }: { viewLink
       </DropDown.Trigger>
 
       <DropDown.Menu>
-        <DropDown.Item onClick={() => open({ type: 'shareLink', props: { type: 'VIEW', link: viewLink } })}>
+        <DropDown.Item
+          onClick={() => {
+            open({ type: 'shareLink', props: { type: 'VIEW', link: 'viewLink' } });
+          }}
+        >
           리스트를 보기 위한 링크 보내기
         </DropDown.Item>
-        <DropDown.Item onClick={() => open({ type: 'shareLink', props: { type: 'EDIT', link: editLink } })}>
+        <DropDown.Item
+          onClick={() => {
+            refreshToken(
+              { id, type: 'place_list' },
+              {
+                onSuccess: (token) => {
+                  const editLink = `${process.env.NEXT_PUBLIC_BASE_URL}/places/${id}?invite_token=${token}`;
+                  open({ type: 'shareLink', props: { type: 'EDIT', link: editLink } });
+                },
+              },
+            );
+          }}
+        >
           수정할 수 있도록 초대
         </DropDown.Item>
         <DropDown.Item>공유 옵션 관리</DropDown.Item>

--- a/components/features/Place/PlaceListDropdwonMenu.tsx
+++ b/components/features/Place/PlaceListDropdwonMenu.tsx
@@ -5,7 +5,12 @@ import { Icon } from '@/components/common/Icon';
 import { useShareEditLink } from '@/hooks/invite-member/useShareEditLink';
 import { useModalStore } from '@/lib/store/modalStore';
 
-export default function PlaceListDropdownMenu({ id }: { id: string }) {
+interface PlaceListDropdownMenuProps {
+  id: string;
+  type?: 'overview' | 'detail';
+}
+
+export default function PlaceListDropdownMenu({ id, type = 'overview' }: PlaceListDropdownMenuProps) {
   const { open } = useModalStore();
   const { createShareLink, isPending } = useShareEditLink();
 
@@ -34,7 +39,9 @@ export default function PlaceListDropdownMenu({ id }: { id: string }) {
           수정할 수 있도록 초대
         </DropDown.Item>
         <DropDown.Item>공유 옵션 관리</DropDown.Item>
-        <DropDown.Item onClick={() => console.log('전체 리스트 편집 페이지로 이동')}>리스트 편집</DropDown.Item>
+        {type === 'detail' && (
+          <DropDown.Item onClick={() => console.log('전체 리스트 편집 페이지로 이동')}>리스트 편집</DropDown.Item>
+        )}
         <DropDown.Item>리스트 삭제</DropDown.Item>
       </DropDown.Menu>
     </DropDown>

--- a/components/features/Place/PlaceListHeader.tsx
+++ b/components/features/Place/PlaceListHeader.tsx
@@ -19,7 +19,10 @@ export default function PlaceListHeader({ listId }: { listId: string }) {
             size={32}
             className='cursor-pointer'
           />
-          <PlaceListDropdownMenu id={listId} />
+          <PlaceListDropdownMenu
+            id={listId}
+            type='detail'
+          />
         </div>
       </div>
 

--- a/components/features/Place/PlaceListHeader.tsx
+++ b/components/features/Place/PlaceListHeader.tsx
@@ -19,10 +19,7 @@ export default function PlaceListHeader({ listId }: { listId: string }) {
             size={32}
             className='cursor-pointer'
           />
-          <PlaceListDropdownMenu
-            viewLink={'공유 링크'}
-            editLink={'초대 링크'}
-          />
+          <PlaceListDropdownMenu id={listId} />
         </div>
       </div>
 

--- a/components/features/Place/PlaceListItem.tsx
+++ b/components/features/Place/PlaceListItem.tsx
@@ -4,6 +4,7 @@ import DropDown from '@/components/common/Dropdown';
 import { Icon } from '@/components/common/Icon';
 import { PlaceListOverview } from '@/types/placeList';
 import Link from 'next/link';
+import PlaceListDropdownMenu from './PlaceListDropdwonMenu';
 
 export default function PlaceListItem({ place }: { place: PlaceListOverview }) {
   return (
@@ -29,21 +30,7 @@ export default function PlaceListItem({ place }: { place: PlaceListOverview }) {
         }}
         className='text-brand-blue-700'
       >
-        <DropDown>
-          <DropDown.Trigger>
-            <Icon
-              name='DotsHorizontal'
-              size={32}
-              className='hover:scale-107'
-            />
-          </DropDown.Trigger>
-          <DropDown.Menu>
-            <DropDown.Item>리스트를 보기 위한 링크 보내기</DropDown.Item>
-            <DropDown.Item>수정할 수 있도록 초대</DropDown.Item>
-            <DropDown.Item>공유 옵션</DropDown.Item>
-            <DropDown.Item>리스트 삭제</DropDown.Item>
-          </DropDown.Menu>
-        </DropDown>
+        <PlaceListDropdownMenu id={place.id} />
       </div>
     </Link>
   );

--- a/components/features/invite/InviteEditorHandler.tsx
+++ b/components/features/invite/InviteEditorHandler.tsx
@@ -3,7 +3,7 @@
 import { useInviteEditorHandler } from '@/hooks/invite-member/useInviteEditorHandler';
 import { ResourceType } from '@/lib/actions/invite';
 
-export default function InviteTokenHandler({ type }: { type: ResourceType }) {
+export default function InviteEditorHandler({ type }: { type: ResourceType }) {
   useInviteEditorHandler(type);
   return null;
 }

--- a/components/features/invite/InviteEditorHandler.tsx
+++ b/components/features/invite/InviteEditorHandler.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { useInviteEditorHandler } from '@/hooks/invite-member/useInviteEditorHandler';
+import { ResourceType } from '@/lib/actions/invite';
+
+export default function InviteTokenHandler({ type }: { type: ResourceType }) {
+  useInviteEditorHandler(type);
+  return null;
+}

--- a/components/features/invite/InviteEditorHandler.tsx
+++ b/components/features/invite/InviteEditorHandler.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useInviteEditorHandler } from '@/hooks/invite-member/useInviteEditorHandler';
-import { ResourceType } from '@/lib/actions/invite';
+import { ResourceType } from '@/types/invite';
 
-export default function InviteEditorHandler({ type }: { type: ResourceType }) {
-  useInviteEditorHandler(type);
+// router를 사용하는 훅을 실행시키기 위한 컴포넌트로, 아무것도 반환하지 X
+export default function InviteEditorHandler({ id, type }: { id: string; type: ResourceType }) {
+  useInviteEditorHandler(id, type);
   return null;
 }

--- a/components/features/provider/ReactQueryConfigContext.tsx
+++ b/components/features/provider/ReactQueryConfigContext.tsx
@@ -1,11 +1,13 @@
 'use client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
 type Props = {
   children: React.ReactNode;
 };
-const queryClient = new QueryClient();
 
 export default function ReactQueryConfigContext({ children }: Props) {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
     <QueryClientProvider client={queryClient}>
       {children}

--- a/components/features/provider/ReactQueryConfigContext.tsx
+++ b/components/features/provider/ReactQueryConfigContext.tsx
@@ -1,12 +1,12 @@
 'use client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useState } from 'react';
+import { getQueryClient } from '@/lib/utils/getQueryClient';
+import { QueryClientProvider } from '@tanstack/react-query';
 type Props = {
   children: React.ReactNode;
 };
 
 export default function ReactQueryConfigContext({ children }: Props) {
-  const [queryClient] = useState(() => new QueryClient());
+  const queryClient = getQueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/hooks/invite-member/useAddEditMember.ts
+++ b/hooks/invite-member/useAddEditMember.ts
@@ -1,0 +1,8 @@
+import { addEditMember, ResourceType } from '@/lib/actions/invite';
+import { useMutation } from '@tanstack/react-query';
+
+export const useAddEditMember = () => {
+  return useMutation({
+    mutationFn: ({ token, type }: { token: string; type: ResourceType }) => addEditMember(token, type),
+  });
+};

--- a/hooks/invite-member/useAddEditMember.ts
+++ b/hooks/invite-member/useAddEditMember.ts
@@ -1,8 +1,9 @@
-import { addEditMember, ResourceType } from '@/lib/actions/invite';
+import { addEditMember } from '@/lib/actions/invite';
+import { AddEditMemberParams } from '@/types/invite';
 import { useMutation } from '@tanstack/react-query';
 
 export const useAddEditMember = () => {
   return useMutation({
-    mutationFn: ({ token, type }: { token: string; type: ResourceType }) => addEditMember(token, type),
+    mutationFn: (params: AddEditMemberParams) => addEditMember(params),
   });
 };

--- a/hooks/invite-member/useGetOrRefreshEditToken.ts
+++ b/hooks/invite-member/useGetOrRefreshEditToken.ts
@@ -1,0 +1,8 @@
+import { ResourceType, verifyEditToken } from '@/lib/actions/invite';
+import { useMutation } from '@tanstack/react-query';
+
+export const useGetOrRefreshEditToken = () => {
+  return useMutation({
+    mutationFn: ({ id, type }: { id: string; type: ResourceType }) => verifyEditToken(id, type),
+  });
+};

--- a/hooks/invite-member/useGetOrRefreshEditToken.ts
+++ b/hooks/invite-member/useGetOrRefreshEditToken.ts
@@ -1,8 +1,9 @@
-import { ResourceType, verifyEditToken } from '@/lib/actions/invite';
+import { verifyEditToken } from '@/lib/actions/invite';
+import { TokenVerifyParams } from '@/types/invite';
 import { useMutation } from '@tanstack/react-query';
 
 export const useGetOrRefreshEditToken = () => {
   return useMutation({
-    mutationFn: ({ id, type }: { id: string; type: ResourceType }) => verifyEditToken(id, type),
+    mutationFn: (params: TokenVerifyParams) => verifyEditToken(params),
   });
 };

--- a/hooks/invite-member/useInviteEditorHandler.ts
+++ b/hooks/invite-member/useInviteEditorHandler.ts
@@ -31,7 +31,7 @@ export const useInviteEditorHandler = (id: string, type: ResourceType) => {
             type: 'error',
             props: {
               title: `${type === 'place_list' ? '장소 리스트' : '계획'} 참여 실패`,
-              description: '초대 링크를 다시 확인해주세요.',
+              description: '초대 링크가 유효하지 않습니다.\n링크를 다시 확인해주세요.',
             },
           });
         },

--- a/hooks/invite-member/useInviteEditorHandler.ts
+++ b/hooks/invite-member/useInviteEditorHandler.ts
@@ -1,18 +1,17 @@
 import { ResourceType } from '@/lib/actions/invite';
-import { usePathname, useSearchParams } from 'next/navigation';
-import { useRouter } from 'next/router';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useAddEditMember } from './useAddEditMember';
 import { useEffect } from 'react';
 
 // 라우터를 감지하고 참여 유저(editor)로 추가하는 훅
 export const useInviteEditorHandler = (type: ResourceType) => {
-  const searchParmas = useSearchParams();
+  const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
   const { mutate: addEditMember } = useAddEditMember();
 
   useEffect(() => {
-    const token = searchParmas.get('invite_token');
+    const token = searchParams.get('invite_token');
     if (!token) return;
 
     addEditMember(
@@ -29,5 +28,5 @@ export const useInviteEditorHandler = (type: ResourceType) => {
         },
       },
     );
-  });
+  }, []);
 };

--- a/hooks/invite-member/useInviteEditorHandler.ts
+++ b/hooks/invite-member/useInviteEditorHandler.ts
@@ -3,18 +3,28 @@ import { useAddEditMember } from './useAddEditMember';
 import { useEffect } from 'react';
 import { useModalStore } from '@/lib/store/modalStore';
 import { ResourceType } from '@/types/invite';
+import { useSession } from 'next-auth/react';
 
 // 라우터를 감지하고 참여 유저(editor)로 추가하는 훅
 export const useInviteEditorHandler = (id: string, type: ResourceType) => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const { data: session, status } = useSession();
   const { mutate: addEditMember } = useAddEditMember();
   const { open } = useModalStore();
 
   useEffect(() => {
     const token = searchParams.get('invite_token');
     if (!token) return;
+
+    // 비로그인 유저일 경우 호출 없이 바로 로그인 페이지로 이동
+    if (status === 'loading') return;
+    if (!session) {
+      // 로그인 이후 다시 참여 로직 시도
+      router.replace('/login');
+      return;
+    }
 
     addEditMember(
       { token, id, type },
@@ -26,7 +36,6 @@ export const useInviteEditorHandler = (id: string, type: ResourceType) => {
         onError: (error) => {
           // 에러 모달
           console.error(error);
-          router.replace(pathname);
           open({
             type: 'error',
             props: {
@@ -34,8 +43,9 @@ export const useInviteEditorHandler = (id: string, type: ResourceType) => {
               description: '초대 링크가 유효하지 않습니다.\n링크를 다시 확인해주세요.',
             },
           });
+          router.replace(pathname);
         },
       },
     );
-  }, []);
+  }, [session]);
 };

--- a/hooks/invite-member/useInviteEditorHandler.ts
+++ b/hooks/invite-member/useInviteEditorHandler.ts
@@ -1,21 +1,23 @@
-import { ResourceType } from '@/lib/actions/invite';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useAddEditMember } from './useAddEditMember';
 import { useEffect } from 'react';
+import { useModalStore } from '@/lib/store/modalStore';
+import { ResourceType } from '@/types/invite';
 
 // 라우터를 감지하고 참여 유저(editor)로 추가하는 훅
-export const useInviteEditorHandler = (type: ResourceType) => {
+export const useInviteEditorHandler = (id: string, type: ResourceType) => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
   const { mutate: addEditMember } = useAddEditMember();
+  const { open } = useModalStore();
 
   useEffect(() => {
     const token = searchParams.get('invite_token');
     if (!token) return;
 
     addEditMember(
-      { token, type },
+      { token, id, type },
       {
         // 토큰 확인되면 토큰 파라미터 제거하고 순수한 링크로 접속
         onSuccess: () => {
@@ -25,6 +27,13 @@ export const useInviteEditorHandler = (type: ResourceType) => {
           // 에러 모달
           console.error(error);
           router.replace(pathname);
+          open({
+            type: 'error',
+            props: {
+              title: `${type === 'place_list' ? '장소 리스트' : '계획'} 참여 실패`,
+              description: '초대 링크를 다시 확인해주세요.',
+            },
+          });
         },
       },
     );

--- a/hooks/invite-member/useInviteEditorHandler.ts
+++ b/hooks/invite-member/useInviteEditorHandler.ts
@@ -1,0 +1,33 @@
+import { ResourceType } from '@/lib/actions/invite';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/router';
+import { useAddEditMember } from './useAddEditMember';
+import { useEffect } from 'react';
+
+// 라우터를 감지하고 참여 유저(editor)로 추가하는 훅
+export const useInviteEditorHandler = (type: ResourceType) => {
+  const searchParmas = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const { mutate: addEditMember } = useAddEditMember();
+
+  useEffect(() => {
+    const token = searchParmas.get('invite_token');
+    if (!token) return;
+
+    addEditMember(
+      { token, type },
+      {
+        // 토큰 확인되면 토큰 파라미터 제거하고 순수한 링크로 접속
+        onSuccess: () => {
+          router.replace(pathname);
+        },
+        onError: (error) => {
+          // 에러 모달
+          console.error(error);
+          router.replace(pathname);
+        },
+      },
+    );
+  });
+};

--- a/hooks/invite-member/useShareEditLink.ts
+++ b/hooks/invite-member/useShareEditLink.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import { useGetOrRefreshEditToken } from './useGetOrRefreshEditToken';
+import { ResourceType } from '@/lib/actions/invite';
+import { useModalStore } from '@/lib/store/modalStore';
+import { RESOURCE_ROUTE } from '@/lib/constants/inviteResourceType';
+
+export const useShareEditLink = () => {
+  const { mutate: refreshToken } = useGetOrRefreshEditToken();
+  const { open } = useModalStore();
+
+  const createShareLink = useCallback(
+    (id: string, type: ResourceType) => {
+      refreshToken(
+        { id, type },
+        {
+          onSuccess: (token) => {
+            const editLink = `${process.env.NEXT_PUBLIC_BASE_URL}/${RESOURCE_ROUTE[type]}/${id}?invite_token=${token}`;
+            open({ type: 'shareLink', props: { type: 'EDIT', link: editLink } });
+          },
+        },
+      );
+    },
+    [refreshToken, open],
+  );
+
+  return { createShareLink };
+};

--- a/hooks/invite-member/useShareEditLink.ts
+++ b/hooks/invite-member/useShareEditLink.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 import { useGetOrRefreshEditToken } from './useGetOrRefreshEditToken';
-import { ResourceType } from '@/lib/actions/invite';
 import { useModalStore } from '@/lib/store/modalStore';
 import { RESOURCE_ROUTE } from '@/lib/constants/inviteResourceType';
+import { ResourceType } from '@/types/invite';
 
 export const useShareEditLink = () => {
   const { mutate: refreshToken } = useGetOrRefreshEditToken();

--- a/hooks/invite-member/useShareEditLink.ts
+++ b/hooks/invite-member/useShareEditLink.ts
@@ -5,7 +5,7 @@ import { RESOURCE_ROUTE } from '@/lib/constants/inviteResourceType';
 import { ResourceType } from '@/types/invite';
 
 export const useShareEditLink = () => {
-  const { mutate: refreshToken } = useGetOrRefreshEditToken();
+  const { mutate: refreshToken, isPending } = useGetOrRefreshEditToken();
   const { open } = useModalStore();
 
   const createShareLink = useCallback(
@@ -14,8 +14,30 @@ export const useShareEditLink = () => {
         { id, type },
         {
           onSuccess: (token) => {
-            const editLink = `${process.env.NEXT_PUBLIC_BASE_URL}/${RESOURCE_ROUTE[type]}/${id}?invite_token=${token}`;
+            const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+            if (!baseUrl) {
+              console.error('NEXT_PUBLIC_BASE_URL이 설정되지 않았습니다.');
+              open({
+                type: 'error',
+                props: {
+                  title: '초대 링크 생성 실패',
+                  description: '초대 링크를 생성하는 도중 문제가 발생했습니다. \n 잠시 후 다시 시도해주세요.',
+                },
+              });
+              return;
+            }
+            const editLink = `${baseUrl}/${RESOURCE_ROUTE[type]}/${id}?invite_token=${token}`;
             open({ type: 'shareLink', props: { type: 'EDIT', link: editLink } });
+          },
+          onError: (error) => {
+            console.error(error);
+            open({
+              type: 'error',
+              props: {
+                title: '초대 링크 생성 실패',
+                description: '초대 링크 생성에 실패했습니다.\n잠시 후 다시 시도해주세요.',
+              },
+            });
           },
         },
       );
@@ -23,5 +45,5 @@ export const useShareEditLink = () => {
     [refreshToken, open],
   );
 
-  return { createShareLink };
+  return { createShareLink, isPending };
 };

--- a/lib/actions/invite.ts
+++ b/lib/actions/invite.ts
@@ -9,7 +9,7 @@ export type ResourceType = 'plan' | 'place_list';
 export const verifyEditToken = async (id: string, type: ResourceType) => {
   const session = await auth();
   if (!session?.user?.id) {
-    throw new Error('인증 정보가 없습니다.');
+    throw new Error('로그인이 필요합니다.');
   }
 
   const supabase = await supabaseUser();
@@ -27,7 +27,7 @@ export const verifyEditToken = async (id: string, type: ResourceType) => {
 export const addEditMember = async (token: string, type: ResourceType) => {
   const session = await auth();
   if (!session?.user?.id) {
-    throw new Error('인증 정보가 없습니다.');
+    throw new Error('로그인이 필요합니다.');
   }
 
   const supabase = await supabaseUser();

--- a/lib/actions/invite.ts
+++ b/lib/actions/invite.ts
@@ -1,0 +1,42 @@
+'use server';
+
+import { auth } from '@/lib/utils/auth';
+import { supabaseUser } from '@/lib/utils/supabase';
+
+export type ResourceType = 'plan' | 'place_list';
+
+// edit 토큰 유효성 검증
+export const verifyEditToken = async (id: string, type: ResourceType) => {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error('인증 정보가 없습니다.');
+  }
+
+  const supabase = await supabaseUser();
+  const { data, error } = await supabase.rpc('get_or_refresh_edit_token', {
+    p_resource_id: id,
+    p_resource_type: type,
+  });
+
+  if (error) throw error;
+  if (!data) throw new Error('토큰이 유효하지 않습니다.');
+  return data; // token
+};
+
+// edit 유저 추가
+export const addEditMember = async (token: string, type: ResourceType) => {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error('인증 정보가 없습니다.');
+  }
+
+  const supabase = await supabaseUser();
+  const { data, error } = await supabase.rpc('add_edit_member', {
+    p_token: token,
+    p_resource_type: type,
+  });
+
+  if (error) throw error;
+  if (!data) throw new Error('유저 초대에 실패했습니다.');
+  return data; // resource_id
+};

--- a/lib/actions/invite.ts
+++ b/lib/actions/invite.ts
@@ -2,11 +2,10 @@
 
 import { auth } from '@/lib/utils/auth';
 import { supabaseUser } from '@/lib/utils/supabase';
-
-export type ResourceType = 'plan' | 'place_list';
+import { AddEditMemberParams, TokenVerifyParams } from '@/types/invite';
 
 // edit 토큰 유효성 검증
-export const verifyEditToken = async (id: string, type: ResourceType) => {
+export const verifyEditToken = async ({ id, type }: TokenVerifyParams) => {
   const session = await auth();
   if (!session?.user?.id) {
     throw new Error('로그인이 필요합니다.');
@@ -24,7 +23,7 @@ export const verifyEditToken = async (id: string, type: ResourceType) => {
 };
 
 // edit 유저 추가
-export const addEditMember = async (token: string, type: ResourceType) => {
+export const addEditMember = async ({ token, id, type }: AddEditMemberParams) => {
   const session = await auth();
   if (!session?.user?.id) {
     throw new Error('로그인이 필요합니다.');
@@ -33,6 +32,7 @@ export const addEditMember = async (token: string, type: ResourceType) => {
   const supabase = await supabaseUser();
   const { data, error } = await supabase.rpc('add_edit_member', {
     p_token: token,
+    p_resource_id: id,
     p_resource_type: type,
   });
 

--- a/lib/constants/inviteResourceType.ts
+++ b/lib/constants/inviteResourceType.ts
@@ -1,0 +1,6 @@
+import { ResourceType } from '../actions/invite';
+
+export const RESOURCE_ROUTE: Record<ResourceType, string> = {
+  place_list: 'places',
+  plan: 'plan',
+};

--- a/lib/constants/inviteResourceType.ts
+++ b/lib/constants/inviteResourceType.ts
@@ -1,4 +1,4 @@
-import { ResourceType } from '../actions/invite';
+import { ResourceType } from '@/types/invite';
 
 export const RESOURCE_ROUTE: Record<ResourceType, string> = {
   place_list: 'places',

--- a/lib/store/modalStore.ts
+++ b/lib/store/modalStore.ts
@@ -13,7 +13,8 @@ import { create } from 'zustand';
 type ModalPayload =
   | { type: 'enterInviteLink' | 'cancelSignup' } // props가 필요 없는 모달
   | { type: 'shareLink'; props: { type: 'VIEW' | 'EDIT'; link: string } }
-  | { type: 'cancelNewPlace'; props: { onCancel: () => void } };
+  | { type: 'cancelNewPlace'; props: { onCancel: () => void } }
+  | { type: 'error'; props: { title: string; description: string } };
 
 interface ModalState {
   activeModal: ModalPayload | null;

--- a/lib/utils/getQueryClient.ts
+++ b/lib/utils/getQueryClient.ts
@@ -1,0 +1,23 @@
+import { environmentManager, QueryClient } from '@tanstack/react-query';
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000, // 기본값: 1분
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+export function getQueryClient() {
+  if (environmentManager.isServer()) {
+    return makeQueryClient();
+  } else {
+    // Browser: QueryClient가 없을 때만 새로 생성
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}

--- a/types/invite.ts
+++ b/types/invite.ts
@@ -1,0 +1,10 @@
+export type ResourceType = 'plan' | 'place_list';
+
+export interface TokenVerifyParams {
+  id: string;
+  type: ResourceType;
+}
+
+export interface AddEditMemberParams extends TokenVerifyParams {
+  token: string;
+}


### PR DESCRIPTION
## 🛠️ 과제 요약
- editor 유저 초대 관련 rpc 구현
- 수정용 링크 생성 기능 적용
- 초대 링크로 접속 시 editor 유저로 추가
- 수정용 링크 생성 실패, 초대 실패 시 에러처리(에러모달) 적용
- #70 해결
## 📝 요구 사항과 구현 내용
#### 1️⃣ 서버: 유저 초대 관련 rpc 구현
- `get_or_refresh_edit_token`: 링크 생성 시 토큰이 유효한지 확인하고 갱신하는 함수(type: plan, place_list에 따라 분기처리)
- `add_edit_member`: editor 유저로 추가하는 함수(type: plan, place_list에 따라 분기처리)
- `can_edit_place_list`, `can_edit_plan`: `get_or_refresh_edit_token`에서 멤버 권한을 확인하기 위해 사용하는 함수
- `is_place_list_member`, `is_place_list_master`: RLS 무한 재귀 호출을 막기 위해 생성한 함수(현재 place_list_member 정책에 적용되어 있음)
#### 2️⃣ 클라이언트: 유저 초대 관련 함수, 훅 생성
- `inviteResourceType.ts`: `ResourceType`을 URL 경로(`places`, `plan`)로 매핑하는 상수
- `invite.ts`: 서버 액션 2개 — `verifyEditToken`(토큰 생성/갱신), `addEditMember`(editor 등록)
- 수정용 모달 생성 시 토큰 확인 및 재발급
  - `useGetOrRefreshEditToken.ts`: `verifyEditToken` 서버 액션을 mutation으로 래핑
  - `useShareEditLink.ts`: 토큰 생성 후 초대 링크를 조합해 shareLink 모달 오픈. `isPending` 반환으로 버튼 중복 클릭 방지
- 생성된 링크로 접속 시 토큰 검증 후 editor로 추가
  - `useAddEditMember.ts`: `addEditMember` 서버 액션을 mutation으로 래핑
  - `useInviteEditorHandler.ts`: URL의 `invite_token` 감지 → 비로그인 시 로그인 redirect → 편집자 등록 → 토큰 파라미터 제거. 성공/실패 에러 처리 포함
- `InviteEditorHandler.tsx`: `useInviteEditorHandler` 훅을 실행하기 위한 클라이언트 컴포넌트 껍데기. `null` 반환
#### 3️⃣ 장소 리스트 드롭다운 메뉴 컴포넌트 공용화
- 각각 따로 구현되어 있어 똑같은 링크 생성 로직을 두 번씩 적용해야 하는 번거로움 발생
- 드롭다운 메뉴 컴포넌트(`PlaceListDropdwonMenu.tsx`)에 type이 overview인지 detail인지에 따라 '리스트 편집' 버튼 숨김처리하는 로직 적용 후 기존 구조 대체 <- 피그마 디자인 반영
#### 4️⃣ Provider.tsx에서 queryClient 선언 위치 변경
- 발생했던 버그와 해결 방법 등 자세한 내용은 #70 에 작성해뒀습니다!
## 🧪 테스트 방법
준비물: 계정 2개 (계정 A: 리스트 소유자, 계정 B: 초대받을 유저)
1. 계정 A로 로그인 후 장소 리스트 상세 페이지 진입
2. 목록 페이지나 상세페이지에서 드롭다운 메뉴 → '수정할 수 있도록 초대' 클릭 → 초대 링크 복사
3. 계정 B로 로그인 후 복사한 링크를 브라우저 주소창에 붙여넣기
4. 계정 B가 장소 리스트 멤버로 추가되는지 확인 (place_list_member 테이블에서 확인)
5. 계정 B의 장소 리스트 목록 페이지에서, 공유된 장소 리스트에 참여한 리스트가 뜨는지 확인

**엣지 케이스**
- 만료된 토큰으로 접근 시 에러 모달 노출 확인
- 이미 멤버인 유저가 초대 링크로 접근 시 에러 없이 정상 진입 확인
- 비로그인 상태에서 초대 링크 접근 시 로그인 페이지로 리다이렉트 확인
- 유효하지 않은 토큰(임의로 변조)으로 접근 시 에러 모달 노출 확인
## 💬 PR 포인트 & 궁금한 점
- viewer, 즉 master나 editor가 아닌 유저는 페이지에 진입했을 때 버튼 액션을 막는 로직이 필요합니다. 별도 브랜치에서 적용할 예정이고, 만들어주신 권한 래퍼를 사용할 예정입니다
- 아직 장소 리스트에만 적용되어 있습니다! 계획 초대 링크 입력 모달 등 plan 참여 로직은 다른 브랜치에서 적용하겠습니다
- 에러 모달이 조금 밤티인데... 나중에 디자인이 수정된다면 반영하겠습니다ㅠ..ㅠ
<img width="400" alt="image" src="https://github.com/user-attachments/assets/893eb74f-9786-4c03-8bf7-112ac766664e" />

## 🔗 연관된 이슈
- close #66
- close #70