### PR TITLE
[Feat/26,33]검색결과 Google Embed API적용

### DIFF
--- a/app/(lobby)/places/(with-pattern)/search/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/search/page.tsx
@@ -2,6 +2,7 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import CoreSearchResultList from '@/components/features/search/CoreSearchResultList';
 import { prefetchPlaceSearch } from '@/lib/actions/prefetch/prefetchPlaceSearch';
+import CoreSearchContainer from '@/components/features/search/CoreSearchContainer';
 
 interface CoreSearchPageProps {
   searchParams: Promise<{ query: string }>;
@@ -26,12 +27,8 @@ export default async function CoreSearchPage({ searchParams }: CoreSearchPagePro
   await prefetchPlaceSearch(queryClient, keyword);
 
   return (
-    <div className='w-full flex flex-col'>
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <QueryBoundary>
-          <CoreSearchResultList keyword={keyword} />
-        </QueryBoundary>
-      </HydrationBoundary>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <CoreSearchContainer keyword={keyword} />
+    </HydrationBoundary>
   );
 }

--- a/app/(lobby)/places/layout.tsx
+++ b/app/(lobby)/places/layout.tsx
@@ -10,9 +10,9 @@ export default function PlaceLayout({
       {children}
 
       {/* 우측 지도 */}
-      <section className='flex-1 bg-brand-blue-50 h-full'>
+      {/* <section className='flex-1 bg-brand-blue-50 h-full'>
         <PlaceMap />
-      </section>
+      </section> */}
     </div>
   );
 }

--- a/app/(new-place)/google-search/page.tsx
+++ b/app/(new-place)/google-search/page.tsx
@@ -127,7 +127,7 @@ export default function SearchGoogle() {
           />
         )}
       </div>
-      <div className='absolute inset-0 ml-118 '>
+      <div className='absolute inset-0 ml-118'>
         <GoogleMapEmbed
           mode={selectedPlace ? 'place' : 'search'}
           googlePlaceId={selectedPlace?.id}

--- a/app/(new-place)/google-search/page.tsx
+++ b/app/(new-place)/google-search/page.tsx
@@ -127,6 +127,7 @@ export default function SearchGoogle() {
           />
         )}
       </div>
+      {/* 구글 embed 영역 */}
       <div className='absolute inset-0 ml-118'>
         <GoogleMapEmbed
           mode={selectedPlace ? 'place' : 'search'}

--- a/app/(new-place)/google-search/page.tsx
+++ b/app/(new-place)/google-search/page.tsx
@@ -13,6 +13,7 @@ import { useGooglePlaceDetail } from '@/hooks/google-search/useGooglePlaceDetail
 import { COUNTRIES, type Country } from '@/lib/utils/countries';
 import { useModalStore } from '@/lib/store/modalStore';
 import SearchForm from '@/components/features/search/GoogleSearchForm';
+import GoogleMapEmbed from '@/components/features/map/GoogleMapEmbed';
 
 export default function SearchGoogle() {
   const searchParams = useSearchParams();
@@ -68,7 +69,7 @@ export default function SearchGoogle() {
   return (
     <div className='relative'>
       <Sidebar />
-      <div className='relative h-screen bg-line-pattern bg-brand-blue-50 ml-[64px]  max-w-102 mx-auto p-4 flex flex-col'>
+      <div className='relative h-screen bg-line-pattern bg-brand-blue-50 ml-[64px]  max-w-102 mx-auto p-4 flex flex-col z-10'>
         {/* 검색 폼 */}
         <SearchForm
           query={query}
@@ -125,6 +126,13 @@ export default function SearchGoogle() {
             }}
           />
         )}
+      </div>
+      <div className='absolute inset-0 ml-118 '>
+        <GoogleMapEmbed
+          mode={selectedPlace ? 'place' : 'search'}
+          googlePlaceId={selectedPlace?.id}
+          query={submittedQuery}
+        />
       </div>
     </div>
   );

--- a/app/api/map/google-embed/route.ts
+++ b/app/api/map/google-embed/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
   let src = '';
 
   if (mode === 'place' && googlePlaceId) {
-    src = `https://www.google.com/maps/embed/v1/place?key=${apiKey}&q=place_id:${googlePlaceId}&language=ko&zoom=16&maptype=roadmap`;
+    src = `https://www.google.com/maps/embed/v1/place?key=${apiKey}&q=place_id:${googlePlaceId}&language=ko&zoom=17&maptype=roadmap`;
   } else if (mode === 'search' && query) {
     src = `https://www.google.com/maps/embed/v1/search?key=${apiKey}&q=${encodeURIComponent(query)}&language=ko&maptype=roadmap`;
   } else {

--- a/app/api/map/google-search/route.ts
+++ b/app/api/map/google-search/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const mode = searchParams.get('mode'); // 'place' | 'search' | 'view'
+  const googlePlaceId = searchParams.get('googlePlaceId');
+  const query = searchParams.get('query');
+
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+
+  let src = '';
+
+  if (mode === 'place' && googlePlaceId) {
+    src = `https://www.google.com/maps/embed/v1/place?key=${apiKey}&q=place_id:${googlePlaceId}&language=ko&zoom=16&maptype=roadmap`;
+  } else if (mode === 'search' && query) {
+    src = `https://www.google.com/maps/embed/v1/search?key=${apiKey}&q=${encodeURIComponent(query)}&language=ko&maptype=roadmap`;
+  } else {
+    src = `https://www.google.com/maps/embed/v1/view?key=${apiKey}&center=37.5665,126.9780&zoom=12&language=ko&maptype=roadmap`;
+  }
+
+  return NextResponse.json({ src });
+}

--- a/components/features/map/GoogleMapEmbed.tsx
+++ b/components/features/map/GoogleMapEmbed.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface GoogleMapEmbedProps {
+  mode: 'place' | 'search' | 'view';
+  googlePlaceId?: string;
+  query?: string;
+}
+
+export default function GoogleMapEmbed({ mode, googlePlaceId, query }: GoogleMapEmbedProps) {
+  const [src, setSrc] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams({ mode });
+    if (googlePlaceId) params.set('googlePlaceId', googlePlaceId);
+    if (query) params.set('query', query);
+
+    fetch(`/api/map/google-search?${params.toString()}`)
+      .then((res) => res.json())
+      .then((data) => setSrc(data.src));
+  }, [mode, googlePlaceId, query]);
+
+  if (!src) return <div className='w-full h-full bg-brand-gray-100' />;
+
+  return (
+    <iframe
+      src={src}
+      className='w-full h-full border-0 z-index-[-1]'
+      loading='lazy'
+      allowFullScreen
+      referrerPolicy='no-referrer-when-downgrade'
+    />
+  );
+}

--- a/components/features/map/GoogleMapEmbed.tsx
+++ b/components/features/map/GoogleMapEmbed.tsx
@@ -16,17 +16,22 @@ export default function GoogleMapEmbed({ mode, googlePlaceId, query }: GoogleMap
     if (googlePlaceId) params.set('googlePlaceId', googlePlaceId);
     if (query) params.set('query', query);
 
-    fetch(`/api/map/google-search?${params.toString()}`)
+    fetch(`/api/map/google-embed?${params.toString()}`)
       .then((res) => res.json())
       .then((data) => setSrc(data.src));
   }, [mode, googlePlaceId, query]);
 
-  if (!src) return <div className='w-full h-full bg-brand-gray-100' />;
+  if (!src)
+    return (
+      <div className='w-full h-full bg-brand-gray-100 flex items-center justify-center'>
+        <p className='text-typo-description text-brand-gray-400'>지도를 불러오는 중...</p>
+      </div>
+    );
 
   return (
     <iframe
       src={src}
-      className='w-full h-full border-0 z-index-[-1]'
+      className='w-full h-full border-0'
       loading='lazy'
       allowFullScreen
       referrerPolicy='no-referrer-when-downgrade'

--- a/components/features/search/CorePlaceSearchResultItem.tsx
+++ b/components/features/search/CorePlaceSearchResultItem.tsx
@@ -3,17 +3,21 @@ import { CorePlaceSearchResult, PLACE_CATEGORIES } from '@/types/CorePlace';
 
 interface CorePlaceSearchResultItemProps {
   result: CorePlaceSearchResult;
+  onClick?: () => void;
 }
 
 const getCategoryLabel = (category: CorePlaceSearchResult['category']) => {
   return PLACE_CATEGORIES.find((item) => item.value === category)?.label ?? null;
 };
 
-export default function CorePlaceSearchResultItem({ result }: CorePlaceSearchResultItemProps) {
+export default function CorePlaceSearchResultItem({ result, onClick }: CorePlaceSearchResultItemProps) {
   const categoryLabel = getCategoryLabel(result.category);
 
   return (
-    <div className='flex flex-col gap-1 p-3 border border-brand-gray-300 rounded-sm bg-brand-gray-0 hover:bg-brand-gray-50 transition-colors'>
+    <div
+      className='flex flex-col gap-1 p-3 border border-brand-gray-300 rounded-sm bg-brand-gray-0 hover:bg-brand-gray-50 transition-colors'
+      onClick={onClick}
+    >
       <div className='flex items-center justify-between'>
         <p className='text-typo-sub-title text-brand-gray-600 font-medium'>{result.name}</p>
         {result.isSaved && (

--- a/components/features/search/CoreSearchContainer.tsx
+++ b/components/features/search/CoreSearchContainer.tsx
@@ -1,11 +1,10 @@
 // components/features/search/CoreSearchContainer.tsx
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import CoreSearchResultList from './CoreSearchResultList';
 import GoogleMapEmbed from '@/components/features/map/GoogleMapEmbed';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
-import type { PlaceSearchResult } from '@/types/CorePlace';
 
 interface CoreSearchContainerProps {
   keyword: string;
@@ -13,6 +12,10 @@ interface CoreSearchContainerProps {
 
 export default function CoreSearchContainer({ keyword }: CoreSearchContainerProps) {
   const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedPlaceId(null);
+  }, [keyword]);
 
   return (
     <div className=' h-screen'>

--- a/components/features/search/CoreSearchContainer.tsx
+++ b/components/features/search/CoreSearchContainer.tsx
@@ -1,0 +1,38 @@
+// components/features/search/CoreSearchContainer.tsx
+'use client';
+
+import { useState } from 'react';
+import CoreSearchResultList from './CoreSearchResultList';
+import GoogleMapEmbed from '@/components/features/map/GoogleMapEmbed';
+import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
+import type { PlaceSearchResult } from '@/types/CorePlace';
+
+interface CoreSearchContainerProps {
+  keyword: string;
+}
+
+export default function CoreSearchContainer({ keyword }: CoreSearchContainerProps) {
+  const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
+
+  return (
+    <div className=' h-screen'>
+      {/* 지도 */}
+      <div className='absolute inset-0 ml-118'>
+        <GoogleMapEmbed
+          mode={selectedPlaceId ? 'place' : 'view'}
+          googlePlaceId={selectedPlaceId ?? undefined}
+        />
+      </div>
+
+      {/* 검색 결과 패널 */}
+      <div className='w-full flex flex-col'>
+        <QueryBoundary>
+          <CoreSearchResultList
+            keyword={keyword}
+            onPlaceSelect={(id) => setSelectedPlaceId(id)}
+          />
+        </QueryBoundary>
+      </div>
+    </div>
+  );
+}

--- a/components/features/search/CoreSearchResultList.tsx
+++ b/components/features/search/CoreSearchResultList.tsx
@@ -9,9 +9,10 @@ import { useEffect, useRef } from 'react';
 
 interface SearchResultListProps {
   keyword: string;
+  onPlaceSelect?: (googlePlaceId: string) => void;
 }
 
-export default function CoreSearchResultList({ keyword }: SearchResultListProps) {
+export default function CoreSearchResultList({ keyword, onPlaceSelect }: SearchResultListProps) {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } = useSearchPlaces(keyword);
   const observerTargetRef = useRef<HTMLDivElement>(null);
 
@@ -46,6 +47,7 @@ export default function CoreSearchResultList({ keyword }: SearchResultListProps)
             <CorePlaceSearchResultItem
               key={item.id}
               result={item}
+              onClick={() => onPlaceSelect?.(item.googlePlaceId)}
             />
           ))}
           {isFetchNextPageError && (

--- a/components/features/search/GooglePlaceDetail.tsx
+++ b/components/features/search/GooglePlaceDetail.tsx
@@ -30,7 +30,7 @@ export default function GooglePlaceDetail({ place, addNewPlace, onClose }: Props
   };
 
   return (
-    <div className='absolute flex-col w-90 min-w-75 top-25 -right-95 flex py-5 px-4 bg-brand-gray-0 rounded-lg shadow-lg'>
+    <div className='absolute flex-col w-90 min-w-75 top-30 -right-92 flex py-5 px-4 bg-brand-gray-0 rounded-lg shadow-lg'>
       <div className='pb-4 border-b-1 border-b-brand-gray-300'>
         <div className='flex-col'>
           <h3 className='text-typo-sub-title text-brand-gray-600 max-w-75'>{getDisplayName(place.displayName.text)}</h3>

--- a/types/CorePlace.ts
+++ b/types/CorePlace.ts
@@ -58,6 +58,7 @@ export interface AutoCompleteResults {
 
 export interface PlaceSearchResult {
   id: string;
+  googlePlaceId: string;
   latitude: number;
   longitude: number;
   name: string;
@@ -66,6 +67,7 @@ export interface PlaceSearchResult {
   savedCount: number;
   averageRating: number;
   reviewCount: number;
+  isSaved: boolean;
 }
 
 export interface PlaceSearchResults {


### PR DESCRIPTION
## 🛠️ 과제 요약

구글 장소 검색 페이지와 DB 검색 페이지에 Google Maps Embed를 연동했습니다.

## 📝 요구 사항과 구현 내용

### 1️⃣ Google Maps Embed 컴포넌트 (`GoogleMapEmbed`)

- `place` / `search` / `view` 세 가지 모드 지원
- API 키 노출 방지를 위해 Route Handler(`/api/map/google-embed`) 경유로 iframe src를 서버에서 생성
- src fetch 전 로딩 placeholder 표시
- Google Cloud Console에서 도메인 제한 설정 권장 (키 노출 방어)

### 2️⃣ 구글 장소 검색 페이지 연동 (`SearchGoogle`)

- 기존 `absolute` 레이아웃에서 검색 패널이 지도 위에 float하는 구조로 변경
- 장소 미선택 시 `search` 모드 (검색어 기준), 장소 선택 시 `place` 모드 (google_place_id 기준)로 자동 전환

### 3️⃣ DB 검색 페이지 연동 (`CoreSearchPage`)

- `CoreSearchContainer` 클라이언트 컴포넌트 신규 추가 — `selectedPlaceId` 상태 관리 및 지도 연동 담당
- 장소 미선택 시 `view` 모드 (서울 기본 좌표), 장소 선택 시 `place` 모드로 전환
- `search_places` RPC에 `google_place_id` 필드 추가 — 지도 연동에 필요한 Google Place ID 반환
- `CorePlaceSearchResultItem`에 `onClick` prop 추가


## 💬 PR 포인트

- layout에서 기본적으로 사용되는 지도와 검색결과에서 사용되는 지도 api에 차이가 있어 상위 layout.tsx에 있던 지도 placeholder를 주석처리했습니다.
- core DB 상세페이지에서도 사용되나 현진님이 추후 페이지 작업을 하실 예정이라 적용하지 않았습니다

 `place` / `search` / `view`모드에 대한 설명
- **place**는 특정 장소 하나만 띄울때 사용합니다
- **search**는 구글 search 검색어 결과와 같은 핀들을 사용할때 사용합니다. 따라서 구글 검색 결과 페이지에서만 사용할 수 있습니다. (DB 조회 결과에서 사용불가 -> 따라서 기본적으로는 서울 지도를 띄우고, 상세페이지 클릭시 place 모드로 해당 장소의 위치를 보여줌)
- **view**는 현재 기본으로 표시되는 서울 중심 지도를 표시할때 사용합니다. 

### 테스트 방법

- DB검색결과 페이지에서 장소 클릭 시 지도 포커스 확인
- 신규 장소 등록 페이지(구글 검색 페이지) 진입 → 기본 서울 지도 표시 확인
- 검색어 입력 후 검색 → `search` 모드로 지도 전환 확인
- 검색 결과 장소 클릭 → `place` 모드로 해당 장소 포커스 확인


## 🔗 연관된 이슈

- close #76 
