### PR TITLE
[Feat/14] lobby페이지 계획 목록 보기 적용(미완: 계획 디테일로 이동 적용)

### DIFF
--- a/app/(lobby)/lobby/page.tsx
+++ b/app/(lobby)/lobby/page.tsx
@@ -1,99 +1,21 @@
+// TODO: 공유 작업 끝나고 서버 컴포넌트로 전환 예정
+'use client';
+
 import JoinPlanButton from '@/components/features/JoinPlanButton';
 import LobbyLastPlanItem from '@/components/features/Plan/LobbyLastPlanItem';
 import LobbyPlanItem from '@/components/features/Plan/LobbyPlanItem';
 import NoticeHeader from '@/components/features/NoticeHeader';
 import Image from 'next/image';
 import Link from 'next/link';
-
-// 임시 데이터 - 추후 API 연동 시 제거 예정
-const PlanItemList = [
-  {
-    id: 1,
-    destination: 'KOR',
-    departure: '2024-07-01',
-    arrival: '2024-07-05',
-    planName: '국내 여행 계획',
-    party: 'group',
-    updatedAt: '2min ago',
-  },
-  {
-    id: 2,
-    destination: 'JPN',
-    departure: '2024-08-10',
-    arrival: '2024-08-15',
-    planName: '일본 여행 계획',
-    party: 'single',
-    updatedAt: '5min ago',
-  },
-  {
-    id: 3,
-    destination: 'USA',
-    departure: '2024-05-01',
-    arrival: '2024-05-10',
-    planName: '미국 여행 계획',
-    party: 'group',
-    updatedAt: '1분 전 수정',
-  },
-  {
-    id: 4,
-    destination: 'FRA',
-    departure: '2024-06-01',
-    arrival: '2024-06-10',
-    planName: '프랑스 여행 계획',
-    party: 'single',
-    updatedAt: '3분 전 수정',
-  },
-];
-
-const LastPlanItemList = [
-  {
-    id: 3,
-    destination: 'USA',
-    departure: '2024-05-01',
-    arrival: '2024-05-10',
-    planName: '미국 여행 계획',
-    party: 'group',
-    updatedAt: '1분 전 수정',
-  },
-  {
-    id: 4,
-    destination: 'FRA',
-    departure: '2024-06-01',
-    arrival: '2024-06-10',
-    planName: '프랑스 여행 계획',
-    party: 'single',
-    updatedAt: '3분 전 수정',
-  },
-  {
-    id: 5,
-    destination: 'ITA',
-    departure: '2024-04-01',
-    arrival: '2024-04-10',
-    planName: '이탈리아 여행 계획',
-    party: 'group',
-    updatedAt: '5분 전 수정',
-  },
-  {
-    id: 6,
-    destination: 'ESP',
-    departure: '2024-03-01',
-    arrival: '2024-03-10',
-    planName: '스페인 여행 계획',
-    party: 'single',
-    updatedAt: '10분 전 수정',
-  },
-  {
-    id: 7,
-    destination: 'GER',
-    departure: '2024-02-01',
-    arrival: '2024-02-10',
-    planName: '독일 여행 계획',
-    party: 'group',
-    updatedAt: '15분 전 수정',
-  },
-];
+import { useGetUserPlans } from '@/hooks/plan/useGetUserPlans';
+import { getTodayDateStr } from '@/lib/utils/date';
 
 export default function Page() {
+  const { data } = useGetUserPlans();
+  const lastPlans = data?.filter(
+    (item) => !item.isDateUndecided && item.arrivalDate && item.arrivalDate < getTodayDateStr(),
+  );
+
   return (
     <div className='h-full max-w-350 min-w-230 mx-auto mt-5.5 pl-16 pr-16 pb-60'>
       <NoticeHeader />
@@ -114,14 +36,15 @@ export default function Page() {
             다가오는 여행
           </div>
           <div className='grid grid-cols-[repeat(auto-fill,275.76px)] gap-10.75'>
-            {PlanItemList.map((plan, index) => (
-              <div
-                key={plan.id}
-                className={index % 2 !== 0 ? 'rotate-2' : '-rotate-2'}
-              >
-                <LobbyPlanItem {...plan} />
-              </div>
-            ))}
+            {data &&
+              data.map((plan, index) => (
+                <div
+                  key={plan.id}
+                  className={index % 2 !== 0 ? 'rotate-2' : '-rotate-2'}
+                >
+                  <LobbyPlanItem {...plan} />
+                </div>
+              ))}
             <Link href='/plan-create'>
               <Image
                 src='/images/lobby-create-plan.svg'
@@ -134,20 +57,22 @@ export default function Page() {
           </div>
         </div>
 
-        <div className='flex flex-col gap-6'>
-          <div className='flex items-center gap-4.5 text-typo-title text-brand-blue-800 font-medium'>
-            <div className='w-2.5 h-2.5 bg-brand-blue-700'></div>
-            지난 여행
+        {lastPlans && (
+          <div className='flex flex-col gap-6'>
+            <div className='flex items-center gap-4.5 text-typo-title text-brand-blue-800 font-medium'>
+              <div className='w-2.5 h-2.5 bg-brand-blue-700'></div>
+              지난 여행
+            </div>
+            <div className='grid grid-cols-[repeat(auto-fill,340px)] gap-3.25'>
+              {lastPlans.map((plan) => (
+                <LobbyLastPlanItem
+                  key={plan.id}
+                  {...plan}
+                />
+              ))}
+            </div>
           </div>
-          <div className='grid grid-cols-[repeat(auto-fill,340px)] gap-3.25'>
-            {LastPlanItemList.map((plan) => (
-              <LobbyLastPlanItem
-                key={plan.id}
-                {...plan}
-              />
-            ))}
-          </div>
-        </div>
+        )}
       </main>
     </div>
   );

--- a/components/features/Plan/LobbyLastPlanItem.tsx
+++ b/components/features/Plan/LobbyLastPlanItem.tsx
@@ -1,39 +1,41 @@
 'use client';
 
+import { PlanOverview } from '@/hooks/plan/useGetUserPlans';
 import { Icon } from '../../common/Icon';
 import LobbyPlanActionMenu from './LobbyPlanActionMenu';
-
-interface LobbyLastPlanItemProps {
-  id: number;
-  destination: string;
-  departure: string;
-  arrival: string;
-  planName: string;
-  party: string;
-  updatedAt: string;
-}
+import Link from 'next/link';
 
 export default function LobbyLastPlanItem({
   id,
   destination,
-  departure,
-  arrival,
-  planName,
-  party,
+  departureDate,
+  arrivalDate,
+  title,
   updatedAt,
-}: LobbyLastPlanItemProps) {
+}: PlanOverview) {
   return (
-    <div className="bg-[url('/images/lobby-plan-folder.svg')] bg-cover bg-center] min-w-85 aspect-340/252 px-7">
+    <Link
+      className="bg-[url('/images/lobby-plan-folder.svg')] bg-cover bg-center] min-w-85 aspect-340/252 px-7"
+      href={`/plan/${id}`}
+    >
       {/* 여행지 */}
       <div className='w-full flex gap-2.75 items-center justify-center mt-10.75'>
         <div className='w-1.5 h-1.5 rounded-full bg-brand-blue-800'></div>
         <span className='flex-1 text-typo-base font-light text-brand-gray-500'>{destination}</span>
 
-        <LobbyPlanActionMenu id={id} />
+        <div
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          className='flex items-center justify-center'
+        >
+          <LobbyPlanActionMenu id={id} />
+        </div>
       </div>
 
       {/* 계획명 */}
-      <p className='text-typo-title text-brand-blue-700 mt-1'>{planName}</p>
+      <p className='text-typo-title text-brand-blue-700 mt-1'>{title ? title : 'Untitled'}</p>
 
       <div className='flex flex-col items-start text-typo-base font-light text-brand-gray-700 mt-19.25 w-full'>
         {/* 여행 기간 */}
@@ -43,12 +45,12 @@ export default function LobbyLastPlanItem({
             size={16}
           />
           <div className='flex flex-1 items-center justify-start gap-2'>
-            <span>{departure}</span>
+            <span>{departureDate}</span>
             <Icon
               name='ArrowRight'
               size={16}
             />
-            <span>{arrival}</span>
+            <span>{arrivalDate}</span>
           </div>
         </div>
 
@@ -61,6 +63,6 @@ export default function LobbyLastPlanItem({
           <span className='flex-1'>{updatedAt}</span>
         </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/components/features/Plan/LobbyPlanActionMenu.tsx
+++ b/components/features/Plan/LobbyPlanActionMenu.tsx
@@ -3,7 +3,7 @@
 import DropDown from '@/components/common/Dropdown';
 import { Icon } from '@/components/common/Icon';
 
-export default function LobbyPlanActionMenu({ id }: { id?: number }) {
+export default function LobbyPlanActionMenu({ id }: { id: string }) {
   return (
     <DropDown>
       <DropDown.Trigger>

--- a/components/features/Plan/LobbyPlanItem.tsx
+++ b/components/features/Plan/LobbyPlanItem.tsx
@@ -1,29 +1,33 @@
+// 마찬가지로 자세한 항목은 추후 수정
 'use client';
 
+import { PlanOverview } from '@/hooks/plan/useGetUserPlans';
 import LobbyPlanActionMenu from './LobbyPlanActionMenu';
-
-interface LobbyPlanItemProps {
-  id: number;
-  destination: string;
-  departure: string;
-  arrival: string;
-  planName: string;
-  party: string;
-  updatedAt: string;
-}
+import Link from 'next/link';
 
 export default function LobbyPlanItem({
   id,
   destination,
-  departure,
-  arrival,
-  planName,
-  party,
+  departureDate,
+  arrivalDate,
+  isDateUndecided,
+  totalDays,
+  title,
+  memberCount,
   updatedAt,
-}: LobbyPlanItemProps) {
+}: PlanOverview) {
   return (
-    <div className="max-w-[275.76px] aspect-[275.76/397.69] bg-[url('/images/lobby-plan.svg')] bg-center bg-cover px-4 pt-19.25 pb-6 flex flex-col drop-shadow-lg">
-      <div className='flex justify-end'>
+    <Link
+      className="max-w-[275.76px] aspect-[275.76/397.69] bg-[url('/images/lobby-plan.svg')] bg-center bg-cover px-4 pt-19.25 pb-6 flex flex-col drop-shadow-lg"
+      href={`/plan/${id}`}
+    >
+      <div
+        className='flex justify-end'
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+      >
         <LobbyPlanActionMenu id={id} />
       </div>
 
@@ -34,25 +38,25 @@ export default function LobbyPlanItem({
 
       {/* 여행 기간 */}
       <div className='flex gap-14.5 font-paperlogy-regular text-[15px] text-brand-gray-500 leading-none tracking-[-1.1%] justify-between items-center mt-14.5 w-full'>
-        <span>{departure}</span>
-        <span>{arrival}</span>
+        <span>{isDateUndecided ? 'start' : departureDate}</span>
+        <span>{isDateUndecided ? 'end' : arrivalDate}</span>
       </div>
 
       {/* 이외의 정보 */}
       <div className='mt-6 text-[12px] font-extralight text-brand-gray-800 w-full'>
         <p className='flex justify-between'>
           <span>plan name</span>
-          {planName}
+          {title ? title : 'Untitled'}
         </p>
         <p className='flex justify-between'>
           <span>party</span>
-          {party}
+          {memberCount > 1 ? 'group' : 'single'}
         </p>
         <p className='flex justify-between'>
           <span>updated</span>
           {updatedAt}
         </p>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/hooks/plan/useGetUserPlans.ts
+++ b/hooks/plan/useGetUserPlans.ts
@@ -8,6 +8,8 @@ export interface PlanOverview {
   arrivalDate: string | null;
   isDateUndecided: boolean;
   totalDays: number;
+  memberCount: number;
+  updatedAt: string;
 }
 
 const fetchUserPlans = async (): Promise<PlanOverview[]> => {

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,0 +1,5 @@
+// 현재 날짜를 YYYY-MM-DD 형식으로 가져오는 함수
+export const getTodayDateStr = (): string => {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+};


### PR DESCRIPTION
## 🛠️ 과제 요약

- 계획 목록 보기 적용

<img width="400" alt="image" src="https://github.com/user-attachments/assets/46491ee7-4a16-44f4-9746-d969ab606934" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/cb953bc8-e55d-4d4f-9501-5df0f1354b0c" />


## 📝 요구 사항과 구현 내용

#### 1️⃣ get_user_plans RPC 수정
- 목록 조회 시 새로운 조회 방식을 적용할 필요성이 낮다고 판단하여 기존 rpc에 updatedAt, memberCount 항목만 추가해 두었습니다. 
  -> updatedAt, memberCount는 일정 추가 시 불러오는 목록에서는 사용되지 않지만, 저비용 필드라 판단하여 별도 엔드포인트 분리 없이 기존 RPC의 SELECT 절에 상관 서브쿼리로 추가했습니다.

#### 2️⃣ 조회 적용
- `useGetUserPlans` 훅을 사용해 계획 목록을 렌더링했습니다.
- 목록 항목 클릭 시 계획 디테일 페이지(`/plan/[id]`)로 이동하는 기능만 우선 구현했습니다.
- 필터링, 정렬, 빈 상태(empty state), UI 등 자세한 사항은 로비 작업 시 추가 예정입니다.

#### 3️⃣ 날짜 관련 유틸함수를 모아두는 date.ts 파일 생성
- 지난 여행을 구분해주기 위해서 유틸함수를 생성해두었습니다
   -> `arrivalDate`가 "YYYY-MM-DD" 형식의 문자열로 내려오기 때문에 Date 객체 변환 없이 문자열 비교로 지난 여행 여부를 판단하도록 설정해두었습니다. 추후 수정될 수 있습니다!
- 날짜 유틸함수는 공용으로 사용할 가능성이 있다면 이 파일에 생성해두는 것을 추천합니다

## 🔗 연관된 이슈
- #14 
