### PR TITLE
[Fix/89] 초대 링크로 접근 시 보기용 유저 차단을 위한 alert 로직이 뜨는 문제 해결

### DIFF
--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -10,11 +10,26 @@ import { getQueryClient } from '@/lib/utils/getQueryClient';
 import { placeListDetailQueryOptions } from '@/hooks/place-list/useGetPlaceListDetail';
 import ForbiddenRedirect from '@/components/features/invite/ForbiddenRedirect';
 import { auth } from '@/lib/utils/auth';
+import { handleInviteAccess } from '@/lib/utils/invite/handleInviteAcess';
 
-export default async function PlaceListDetail({ params }: { params: Promise<{ listId: string }> }) {
+export default async function PlaceListDetail({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ listId: string }>;
+  searchParams: Promise<{ invite_token?: string }>;
+}) {
   const { listId } = await params;
   const session = await auth(); // 버튼 렌더링 여부 결정을 위해 세션 조회
   const queryClient = getQueryClient();
+  const { invite_token: inviteToken } = await searchParams;
+
+  await handleInviteAccess({
+    inviteToken,
+    session,
+    resourceId: listId,
+    resourceType: 'place_list',
+  });
 
   try {
     // 헤더 조회에서 FORBIDDEN을 바로 판단
@@ -31,10 +46,7 @@ export default async function PlaceListDetail({ params }: { params: Promise<{ li
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <Suspense fallback={null}>
-        <InviteEditorHandler
-          id={listId}
-          resourceType='place_list'
-        />
+        <InviteEditorHandler hasInviteToken={!!inviteToken} />
       </Suspense>
       <div className='flex flex-col gap-5.5'>
         <QueryBoundary>

--- a/components/features/invite/InviteEditorHandler.tsx
+++ b/components/features/invite/InviteEditorHandler.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { useInviteEditorHandler } from '@/hooks/invite-member/useInviteEditorHandler';
-import { InviteHookParams } from '@/types/invite';
 
 // router를 사용하는 훅을 실행시키기 위한 컴포넌트로, 아무것도 반환하지 X
-export default function InviteEditorHandler({ id, resourceType }: InviteHookParams) {
-  useInviteEditorHandler({ id, resourceType });
+export default function InviteEditorHandler({ hasInviteToken }: { hasInviteToken: boolean }) {
+  useInviteEditorHandler({ hasInviteToken });
   return null;
 }

--- a/hooks/invite-member/useInviteEditorHandler.ts
+++ b/hooks/invite-member/useInviteEditorHandler.ts
@@ -1,60 +1,15 @@
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useAddEditMember } from './useAddEditMember';
+import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
-import { useModalStore } from '@/lib/store/modalStore';
-import { InviteHookParams } from '@/types/invite';
-import { useSession } from 'next-auth/react';
-import { DEFAULT_INVITE_ERROR_PROPS, INVITE_ERROR_MESSAGES, InviteErrorCode } from '@/lib/constants/inviteErrorMessage';
-import { useQueryClient } from '@tanstack/react-query';
 
-// 라우터를 감지하고 참여 유저(editor)로 추가하는 훅
-export const useInviteEditorHandler = ({ id, resourceType }: InviteHookParams) => {
-  const queryclient = useQueryClient();
-  const searchParams = useSearchParams();
+// 라우터를 감지하고 페이지 내부에서 모달 에러를 띄울 일이 있을 때 + invite_token 파라미터를 제거하는 훅
+export const useInviteEditorHandler = ({ hasInviteToken }: { hasInviteToken: boolean }) => {
   const router = useRouter();
   const pathname = usePathname();
-  const { data: session, status } = useSession();
-  const { mutate: addEditMember } = useAddEditMember();
-  const { open } = useModalStore();
 
   useEffect(() => {
-    const token = searchParams.get('invite_token');
-    if (!token) return;
+    if (!hasInviteToken) return;
 
-    // 비로그인 유저일 경우 호출 없이 바로 로그인 페이지로 이동
-    if (status === 'loading') return;
-    if (!session) {
-      // 로그인 이후 다시 참여 로직 시도
-      router.replace('/login');
-      return;
-    }
-
-    // 여기까지 넘어왔을 때는 이미 라우팅 성공 이후
-    addEditMember(
-      { token, id, type: resourceType },
-      {
-        // 토큰 확인되면 토큰 파라미터 제거하고 순수한 링크로 접속
-        onSuccess: (result) => {
-          if ('error' in result) {
-            open({
-              type: 'error',
-              props: INVITE_ERROR_MESSAGES[resourceType][result.error as InviteErrorCode] ?? DEFAULT_INVITE_ERROR_PROPS,
-            });
-            router.replace(pathname);
-            return;
-          }
-
-          queryclient.invalidateQueries({
-            // TODO: plan 전체조회 쿼리키 확인 필요
-            queryKey: resourceType === 'plan' ? ['plan', 'list'] : ['place-list'],
-          });
-
-          router.replace(pathname);
-        },
-        onError: (error) => {
-          console.error(error);
-        },
-      },
-    );
-  }, [session, searchParams]);
+    // 여기까지 넘어왔을 때는 이미 라우팅 및 참여 성공 이후
+    router.replace(pathname);
+  }, []);
 };

--- a/lib/utils/invite/handleInviteAcess.ts
+++ b/lib/utils/invite/handleInviteAcess.ts
@@ -1,0 +1,36 @@
+// 서버 컴포넌트 전용 유틸함수
+// 페이지(서버 컴포넌트) 접근 시, inviteToken이 있으면 addEditMember를 수행하고, 에러가 발생하면 /invite-invalid로 리다이렉트
+
+import { redirect } from 'next/navigation';
+import type { Session } from 'next-auth';
+import { addEditMember } from '@/lib/actions/invite';
+import { ResourceType } from '@/types/invite';
+import { RESOURCE_ROUTE } from '@/lib/constants/ResourceType';
+
+interface HandleInviteAccessParams {
+  inviteToken: string | undefined;
+  session: Session | null;
+  resourceId: string;
+  resourceType: ResourceType;
+}
+
+export async function handleInviteAccess({
+  inviteToken,
+  session,
+  resourceId,
+  resourceType,
+}: HandleInviteAccessParams): Promise<void> {
+  if (!inviteToken) return;
+
+  if (!session) {
+    redirect(
+      `/login?callbackUrl=${encodeURIComponent(`/${RESOURCE_ROUTE[resourceType]}/${resourceId}?invite_token=${inviteToken}`)}`,
+    );
+  }
+
+  const result = await addEditMember({ token: inviteToken, id: resourceId, type: resourceType });
+
+  if ('error' in result) {
+    redirect('/invite-invalid');
+  }
+}


### PR DESCRIPTION
## 🛠️ 과제 요약

- 초대 링크로 접근 시 보기용 유저 차단을 위한 alert 로직이 뜨는 문제 해결

## 📝 요구 사항과 구현 내용

1️⃣ 참여 유저 추가 로직을 forbidden 판단 이후에 실행하도록 수정
- `handleInviteAccess.ts` 유틸함수 생성
  - 초대 토큰과 세션 유무에 따라 참여 유저 추가 함수를 실행
  - 세션이 없을 땐 login페이지로, 참여 유저 에러가 발생하면 /invite-invalid 페이지로 리다이렉트 처리
  ⚠️ 서버 컴포넌트에서 NextResponse를 사용할 수 없는 관계로 redirect를 이용해 /invite-invalid 경로로 리다이렉트 결정

2️⃣ inviteEditorHandler.tsx에서 실행하는 useInviteEditorHandler.ts 훅 역할 축소
- 해당 컴포넌트는 모든 조회가 끝난 이후 페이지가 렌더링되기 전 실행되는 return값이 없는 컴포넌트
- 기존에는 useInviteEditorHandler.ts 이 훅에서 참여 유저 추가를 담당했으나, 조회 이전에 참여 유저 추가가 완료되어야 함에 따라 해당 훅의 역할을 축소
- 참여 유저 추가 로직은 `handleInviteAccess.ts`로 이관하고, 이 훅에서는 pathname에서 invite_token 파라미터를 제거하는 역할만 담당하도록 수정

## 💬 PR 포인트 & 궁금한 점

- 계획에서도 동일한 적용이 필요합니다!(참고: `app/(lobby)/places/(with-pattern)/[listId]/page.tsx`)
- 적용 순서
   1. 페이지 `searchParams: Promise<{ invite_token?: string }>;` 로 `invite_token` 조회
   2. 데이터 조회 로직이 실행되기 전, handleInviteAccess 로직을 비동기로 먼저 수행
   ```typescript
    await handleInviteAccess({
      inviteToken,
      session,
      resourceId: listId,
      resourceType: 'plan',
    });
   ```
   3. ⚠️  계획을 조회하는 조회 RPC에서 멤버인지, is_public인지를 먼저 조회하는 방어 로직이 짜여져 있어야 합니다
   ```typescript
   // 적용 예시입니다. 계획 조회 방식에 따라 수정해주시면 됩니다
   try {
    // 헤더 조회에서 FORBIDDEN을 바로 판단
    await queryClient.fetchQuery(placeListDetailQueryOptions(listId));
  } catch (error) {
    if (error instanceof Error && error.message === '42501') {
      return <ForbiddenRedirect />;
    }
    throw error;
  }
  await prefetchPlaceListDetail(queryClient, listId);
   ```
   4. 서버 컴포넌트 return문 가장 상위에 InviteEditorHandler 컴포넌트 적용 필수(pathname제거용)
   ```
   <Suspense fallback={null}>
        <InviteEditorHandler hasInviteToken={!!inviteToken} /> 
    </Suspense>
   ```

## 🧪 테스트 방법
공통 (place_list 우선 확인, plan 은 동일 로직 적용 후 테스트 필요)
### 1. Viewer 접근 시
- 로그인 유저
  - is_public=true -> 정상 조회, 사이드바 노출
  - is_public=false + 비멤버 → alert 노출 → 확인 시 /lobby 이동
- 비로그인 유저
  - is_public=true → 정상 조회, 사이드바 로그인 버튼 확인 + 검색창, 드롭다운 메뉴 버튼 미노출
  - is_public=false → alert 노출 → 확인 시 /login 이동

### 2. Editor 초대 링크 접근 시
- 로그인 유저
  - 유효한 초대 링크 URL 직접 접속 → 참여 성공, 목록 최상단에 반영, URL에서 invite_token 제거 확인
  - 만료/무효 토큰으로 URL 직접 접속 → /invite-invalid(not-found 페이지)로 즉시 이동 (alert 없이)
  - 이미 참여 중인 멤버가 만료된 토큰으로 재접속 → 에러 없이 정상 접속
- 비로그인 유저
  - 초대 링크 접속 → /login 이동

## 🔗 연관된 이슈
- close #89 

