### PR TITLE
[Feat] 새로운 에러 타입 적용

### DIFF
--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -56,7 +56,7 @@ export default async function PlaceListDetail({
         <InviteEditorHandler hasInviteToken={!!inviteToken} />
       </Suspense>
       <div className='flex flex-col gap-5.5'>
-        <QueryBoundary actionLabel='리스트 상세정보'>
+        <QueryBoundary subject='리스트 상세정보'>
           <PlaceListHeader
             listId={listId}
             hasSession={!!session}
@@ -64,10 +64,10 @@ export default async function PlaceListDetail({
         </QueryBoundary>
 
         <div className='flex flex-col gap-3'>
-          <QueryBoundary actionLabel='태그'>
+          <QueryBoundary subject='태그'>
             <TagList listId={listId} />
           </QueryBoundary>
-          <QueryBoundary actionLabel='저장된 장소'>
+          <QueryBoundary subject='저장된 장소'>
             <PlaceListPlaces listId={listId} />
           </QueryBoundary>
         </div>

--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -42,7 +42,7 @@ export default async function PlaceListDetail({
       queryFn: () => getPlaceListDetail({ supabase, listId }),
     });
   } catch (error) {
-    if (error instanceof RpcError && error.code === '42501') {
+    if (error instanceof RpcError && error.message === 'FORBIDDEN') {
       return <ForbiddenRedirect />;
     }
     throw error;

--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -56,7 +56,7 @@ export default async function PlaceListDetail({
         <InviteEditorHandler hasInviteToken={!!inviteToken} />
       </Suspense>
       <div className='flex flex-col gap-5.5'>
-        <QueryBoundary>
+        <QueryBoundary actionLabel='리스트 상세정보'>
           <PlaceListHeader
             listId={listId}
             hasSession={!!session}
@@ -64,10 +64,10 @@ export default async function PlaceListDetail({
         </QueryBoundary>
 
         <div className='flex flex-col gap-3'>
-          <QueryBoundary>
+          <QueryBoundary actionLabel='태그'>
             <TagList listId={listId} />
           </QueryBoundary>
-          <QueryBoundary>
+          <QueryBoundary actionLabel='저장된 장소'>
             <PlaceListPlaces listId={listId} />
           </QueryBoundary>
         </div>

--- a/app/api/view/members/route.ts
+++ b/app/api/view/members/route.ts
@@ -1,4 +1,5 @@
 import { supabaseUser } from '@/lib/utils/supabase';
+import { RPC_ERROR_TO_STATUS, RpcError, RpcErrorMessage } from '@/types/errors';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
@@ -16,14 +17,17 @@ export async function GET(request: NextRequest) {
       p_resource_id: resourceId,
       p_resource_type: resourceType,
     });
-
-    if (error) throw error;
+    if (error) throw new RpcError(error.message as RpcErrorMessage, error.code);
     return NextResponse.json(data ?? [], { status: 200 });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('❌ 참여 유저 목록 호출 실패:', error);
-    if (error.code === '42501') {
-      return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+    if (error instanceof RpcError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: RPC_ERROR_TO_STATUS[error.message as RpcErrorMessage] ?? 500 },
+      );
     }
-    return NextResponse.json({ error: '참여 유저 목록을 불러오는 중 오류가 발생했습니다.' }, { status: 500 });
+
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 });
   }
 }

--- a/app/api/view/place-list/[listId]/detail/route.ts
+++ b/app/api/view/place-list/[listId]/detail/route.ts
@@ -1,6 +1,6 @@
 import { getPlaceListDetail } from '@/lib/actions/api/placeList';
 import { supabaseUser } from '@/lib/utils/supabase';
-import { RpcError } from '@/types/errors';
+import { RPC_ERROR_TO_STATUS, RpcError, RpcErrorMessage } from '@/types/errors';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ listId: string }> }) {
@@ -12,10 +12,14 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     return NextResponse.json(data);
   } catch (error: unknown) {
     console.error('❌ 리스트 상세 헤더 조회 실패: ', error);
-    if (error instanceof RpcError && error.code === '42501') {
-      return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+
+    if (error instanceof RpcError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: RPC_ERROR_TO_STATUS[error.message as RpcErrorMessage] ?? 500 },
+      );
     }
-    const message = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';
-    return NextResponse.json({ error: message }, { status: 500 });
+
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 });
   }
 }

--- a/app/api/view/place-list/[listId]/tags/route.ts
+++ b/app/api/view/place-list/[listId]/tags/route.ts
@@ -1,6 +1,6 @@
 import { getPlaceListTags } from '@/lib/actions/api/placeList';
 import { supabaseUser } from '@/lib/utils/supabase';
-import { RpcError } from '@/types/errors';
+import { RPC_ERROR_TO_STATUS, RpcError, RpcErrorMessage } from '@/types/errors';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ listId: string }> }) {
@@ -11,12 +11,15 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     const data = await getPlaceListTags({ supabase, listId });
     return NextResponse.json(data);
   } catch (error: unknown) {
-    console.error('❌ 리스트 상세 헤더 조회 실패: ', error);
-    if (error instanceof RpcError && error.code === '42501') {
-      return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+    console.error('❌ 리스트 상세 태그 조회 실패: ', error);
+
+    if (error instanceof RpcError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: RPC_ERROR_TO_STATUS[error.message as RpcErrorMessage] ?? 500 },
+      );
     }
 
-    const message = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 });
   }
 }

--- a/components/common/ui/boundary/Queryboundary.tsx
+++ b/components/common/ui/boundary/Queryboundary.tsx
@@ -12,7 +12,7 @@ interface QueryBoundaryProps {
 }
 
 export function QueryBoundary({ children, errorFallback, subject }: QueryBoundaryProps) {
-  const fallback = errorFallback ?? ((props: FallbackProps) => defaultErrorFallback(props, subject ?? '요청'));
+  const fallback = errorFallback ?? ((props: FallbackProps) => defaultErrorFallback(props, subject ?? '대상'));
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
@@ -31,7 +31,7 @@ function defaultErrorFallback({ error, resetErrorBoundary }: FallbackProps, subj
   let errorMessage = '알 수 없는 에러가 발생했습니다.';
 
   if (error instanceof RpcError) {
-    errorMessage = getErrorMessage(error.message as RpcErrorMessage, subject);
+    errorMessage = getErrorMessage(error.message as RpcErrorMessage, { subject, action: '조회' });
   } else if (error instanceof Error) {
     // TODO: 추후 삭제 필요 - 아직 수정 안 한 쿼리들을 위해 남겨둠
     errorMessage = error.message;

--- a/components/common/ui/boundary/Queryboundary.tsx
+++ b/components/common/ui/boundary/Queryboundary.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ERROR_MESSAGES, RpcError, RpcErrorMessage } from '@/types/errors';
+import { getErrorMessage, RpcError, RpcErrorMessage } from '@/types/errors';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
@@ -8,15 +8,17 @@ import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 interface QueryBoundaryProps {
   children: React.ReactNode;
   errorFallback?: (props: FallbackProps) => React.ReactNode;
+  actionLabel?: string;
 }
 
-export function QueryBoundary({ children, errorFallback }: QueryBoundaryProps) {
+export function QueryBoundary({ children, errorFallback, actionLabel }: QueryBoundaryProps) {
+  const fallback = errorFallback ?? ((props: FallbackProps) => defaultErrorFallback(props, actionLabel ?? '요청'));
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
         <ErrorBoundary
           onReset={reset}
-          fallbackRender={errorFallback ?? defaultErrorFallback}
+          fallbackRender={fallback}
         >
           <Suspense>{children}</Suspense>
         </ErrorBoundary>
@@ -25,11 +27,11 @@ export function QueryBoundary({ children, errorFallback }: QueryBoundaryProps) {
   );
 }
 
-function defaultErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+function defaultErrorFallback({ error, resetErrorBoundary }: FallbackProps, actionLabel: string) {
   let errorMessage = '알 수 없는 에러가 발생했습니다.';
 
   if (error instanceof RpcError) {
-    errorMessage = ERROR_MESSAGES[error.message as RpcErrorMessage] ?? ERROR_MESSAGES.INTERNAL_ERROR;
+    errorMessage = getErrorMessage(error.message as RpcErrorMessage, actionLabel);
   } else if (error instanceof Error) {
     // TODO: 추후 삭제 필요 - 아직 수정 안 한 쿼리들을 위해 남겨둠
     errorMessage = error.message;

--- a/components/common/ui/boundary/Queryboundary.tsx
+++ b/components/common/ui/boundary/Queryboundary.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ERROR_MESSAGES, RpcError, RpcErrorMessage } from '@/types/errors';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
@@ -26,7 +27,11 @@ export function QueryBoundary({ children, errorFallback }: QueryBoundaryProps) {
 
 function defaultErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   let errorMessage = '알 수 없는 에러가 발생했습니다.';
-  if (error instanceof Error) {
+
+  if (error instanceof RpcError) {
+    errorMessage = ERROR_MESSAGES[error.message as RpcErrorMessage] ?? ERROR_MESSAGES.INTERNAL_ERROR;
+  } else if (error instanceof Error) {
+    // TODO: 추후 삭제 필요 - 아직 수정 안 한 쿼리들을 위해 남겨둠
     errorMessage = error.message;
   }
 

--- a/components/common/ui/boundary/Queryboundary.tsx
+++ b/components/common/ui/boundary/Queryboundary.tsx
@@ -8,11 +8,11 @@ import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 interface QueryBoundaryProps {
   children: React.ReactNode;
   errorFallback?: (props: FallbackProps) => React.ReactNode;
-  actionLabel?: string;
+  subject?: string;
 }
 
-export function QueryBoundary({ children, errorFallback, actionLabel }: QueryBoundaryProps) {
-  const fallback = errorFallback ?? ((props: FallbackProps) => defaultErrorFallback(props, actionLabel ?? '요청'));
+export function QueryBoundary({ children, errorFallback, subject }: QueryBoundaryProps) {
+  const fallback = errorFallback ?? ((props: FallbackProps) => defaultErrorFallback(props, subject ?? '요청'));
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
@@ -27,11 +27,11 @@ export function QueryBoundary({ children, errorFallback, actionLabel }: QueryBou
   );
 }
 
-function defaultErrorFallback({ error, resetErrorBoundary }: FallbackProps, actionLabel: string) {
+function defaultErrorFallback({ error, resetErrorBoundary }: FallbackProps, subject: string) {
   let errorMessage = '알 수 없는 에러가 발생했습니다.';
 
   if (error instanceof RpcError) {
-    errorMessage = getErrorMessage(error.message as RpcErrorMessage, actionLabel);
+    errorMessage = getErrorMessage(error.message as RpcErrorMessage, subject);
   } else if (error instanceof Error) {
     // TODO: 추후 삭제 필요 - 아직 수정 안 한 쿼리들을 위해 남겨둠
     errorMessage = error.message;

--- a/components/features/place-list/PlaceListShareOptionModal.tsx
+++ b/components/features/place-list/PlaceListShareOptionModal.tsx
@@ -25,7 +25,7 @@ export default function PlaceListShareOptionModal({ id, onClose }: { id: string;
             onClick={onClose}
           />
         </header>
-        <QueryBoundary actionLabel='공유 옵션 조회'>
+        <QueryBoundary subject='공유 옵션 조회'>
           <ShareOptionContent
             id={id}
             resourceType='place_list'

--- a/components/features/place-list/PlaceListShareOptionModal.tsx
+++ b/components/features/place-list/PlaceListShareOptionModal.tsx
@@ -25,7 +25,7 @@ export default function PlaceListShareOptionModal({ id, onClose }: { id: string;
             onClick={onClose}
           />
         </header>
-        <QueryBoundary>
+        <QueryBoundary actionLabel='공유 옵션 조회'>
           <ShareOptionContent
             id={id}
             resourceType='place_list'

--- a/hooks/place-list/useDeletePlaceList.ts
+++ b/hooks/place-list/useDeletePlaceList.ts
@@ -28,8 +28,8 @@ export const useDeletePlaceList = () => {
 
       const message =
         error instanceof RpcError
-          ? getErrorMessage(error.message as RpcErrorMessage, '장소 리스트 삭제')
-          : getErrorMessage('INTERNAL_ERROR', '장소 리스트 삭제');
+          ? getErrorMessage(error.message as RpcErrorMessage, { subject: '장소 리스트', action: '삭제' })
+          : getErrorMessage('INTERNAL_ERROR', { subject: '장소 리스트', action: '삭제' });
 
       open({
         type: 'error',

--- a/hooks/place-list/useDeletePlaceList.ts
+++ b/hooks/place-list/useDeletePlaceList.ts
@@ -1,4 +1,4 @@
-import { RpcError } from '@/types/errors';
+import { getErrorMessage, RpcError, RpcErrorMessage } from '@/types/errors';
 import { deletePlaceList } from '@/lib/actions/placeList';
 import { useModalStore } from '@/lib/store/modalStore';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -12,8 +12,8 @@ export const useDeletePlaceList = () => {
     mutationFn: async (listId: string) => {
       const result = await deletePlaceList(listId);
 
-      if ('error' in result) {
-        throw new RpcError(result.error, result.code);
+      if (!result.success) {
+        throw new RpcError(result.error.message, result.error.code);
       }
 
       return result;
@@ -25,11 +25,17 @@ export const useDeletePlaceList = () => {
     },
     onError: (error) => {
       console.error('❌ 참여 유저 삭제 실패');
+
+      const message =
+        error instanceof RpcError
+          ? getErrorMessage(error.message as RpcErrorMessage, '장소 리스트 삭제')
+          : getErrorMessage('INTERNAL_ERROR', '장소 리스트 삭제');
+
       open({
         type: 'error',
         props: {
           title: '장소 리스트 삭제 실패',
-          description: `${error.message}\n잠시 후 다시 시도해주세요.`,
+          description: `${message}\n잠시 후 다시 시도해주세요.`,
         },
       });
     },

--- a/hooks/place-list/useGetPlaceListDetail.ts
+++ b/hooks/place-list/useGetPlaceListDetail.ts
@@ -1,11 +1,16 @@
-import { RpcError } from '@/types/errors';
+import { RpcError, RpcErrorMessage, RpcErrorResponseBody } from '@/types/errors';
 import { PlaceListDetail } from '@/types/placeList';
 import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
 
 const fetchPlaceListDetail = async (listId: string): Promise<PlaceListDetail> => {
   const res = await fetch(`/api/view/place-list/${listId}/detail`);
-  if (res.status === 401) throw new RpcError('UNAUTHORIZED');
-  if (!res.ok) throw new RpcError('장소 리스트 정보를 가져오는 데 실패했습니다.');
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as RpcErrorResponseBody | null;
+    const message: RpcErrorMessage = body?.error ?? 'INTERNAL_ERROR';
+    throw new RpcError(message);
+  }
+
   return res.json();
 };
 

--- a/hooks/place-list/useGetPlaceListTags.ts
+++ b/hooks/place-list/useGetPlaceListTags.ts
@@ -1,11 +1,16 @@
-import { RpcError } from '@/types/errors';
+import { RpcError, RpcErrorMessage, RpcErrorResponseBody } from '@/types/errors';
 import { Tag } from '@/types/placeList';
 import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
 
 const fetchPlaceListTags = async (listId: string): Promise<Tag[]> => {
   const res = await fetch(`/api/view/place-list/${listId}/tags`);
-  if (res.status === 401) throw new RpcError('UNAUTHORIZED');
-  if (!res.ok) throw new RpcError('장소 리스트에 저장된 태그를 가져오는 데 실패했습니다.');
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as RpcErrorResponseBody | null;
+    const message: RpcErrorMessage = body?.error ?? 'INTERNAL_ERROR';
+    throw new RpcError(message);
+  }
+
   return res.json();
 };
 

--- a/hooks/shareOption/useDeleteMember.ts
+++ b/hooks/shareOption/useDeleteMember.ts
@@ -1,7 +1,7 @@
 import { deleteMember } from '@/lib/actions/shareOption';
 import { RESOURCE_QUERY_KEY } from '@/lib/constants/ResourceType';
 import { useModalStore } from '@/lib/store/modalStore';
-import { RpcError } from '@/types/errors';
+import { getErrorMessage, RpcError, RpcErrorMessage } from '@/types/errors';
 import { DeleteMemberParams, ResourceParams } from '@/types/shareOption';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -14,8 +14,8 @@ export const useDeleteMember = ({ id, resourceType }: ResourceParams) => {
       const result = await deleteMember(params);
 
       // 에러 던지기 -> onError에서 잡음
-      if ('error' in result) {
-        throw new RpcError(result.error, result.code);
+      if (!result.success) {
+        throw new RpcError(result.error.message, result.error.code);
       }
 
       return result;
@@ -27,11 +27,17 @@ export const useDeleteMember = ({ id, resourceType }: ResourceParams) => {
     },
     onError: (error) => {
       console.error('참여 유저 삭제 실패: ', error.message);
+
+      const message =
+        error instanceof RpcError
+          ? getErrorMessage(error.message as RpcErrorMessage, '참여 유저 삭제')
+          : getErrorMessage('INTERNAL_ERROR', '참여 유저 삭제');
+
       open({
         type: 'error',
         props: {
           title: '참여 유저 삭제 실패',
-          description: `${error.message}\n잠시 후 다시 시도해주세요.`,
+          description: `${message}\n잠시 후 다시 시도해주세요.`,
         },
       });
     },

--- a/hooks/shareOption/useDeleteMember.ts
+++ b/hooks/shareOption/useDeleteMember.ts
@@ -30,8 +30,8 @@ export const useDeleteMember = ({ id, resourceType }: ResourceParams) => {
 
       const message =
         error instanceof RpcError
-          ? getErrorMessage(error.message as RpcErrorMessage, '참여 유저 삭제')
-          : getErrorMessage('INTERNAL_ERROR', '참여 유저 삭제');
+          ? getErrorMessage(error.message as RpcErrorMessage, { subject: '참여 유저', action: '삭제' })
+          : getErrorMessage('INTERNAL_ERROR', { subject: '참여 유저', action: '삭제' });
 
       open({
         type: 'error',

--- a/hooks/shareOption/useGetMembers.ts
+++ b/hooks/shareOption/useGetMembers.ts
@@ -1,19 +1,24 @@
 import { RESOURCE_QUERY_KEY } from '@/lib/constants/ResourceType';
-import { RpcError } from '@/types/errors';
+import { RpcError, RpcErrorMessage, RpcErrorResponseBody } from '@/types/errors';
 import { Member, ResourceParams } from '@/types/shareOption';
 import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+
+const fetchMembers = async ({ id, resourceType }: ResourceParams): Promise<Member[]> => {
+  const res = await fetch(`/api/view/members?id=${id}&resourceType=${resourceType}`);
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as RpcErrorResponseBody | null;
+    const message: RpcErrorMessage = body?.error ?? 'INTERNAL_ERROR';
+    throw new RpcError(message);
+  }
+
+  return res.json();
+};
 
 export const membersQueryOptions = ({ id, resourceType }: ResourceParams) => {
   return queryOptions({
     queryKey: ['members', RESOURCE_QUERY_KEY[resourceType], id],
-    queryFn: async () => {
-      const res = await fetch(`/api/view/members?id=${id}&resourceType=${resourceType}`);
-
-      if (res.status === 403) throw new RpcError('참여 유저 목록을 불러올 수 없습니다.');
-      if (!res.ok) throw new RpcError('참여 유저 목록을 불러오는 중 오류가 발생했습니다.');
-
-      return res.json() as Promise<Member[]>;
-    },
+    queryFn: () => fetchMembers({ id, resourceType }),
   });
 };
 

--- a/hooks/shareOption/useSetPublic.ts
+++ b/hooks/shareOption/useSetPublic.ts
@@ -1,7 +1,7 @@
 import { setPublic } from '@/lib/actions/shareOption';
 import { RESOURCE_QUERY_KEY } from '@/lib/constants/ResourceType';
 import { useModalStore } from '@/lib/store/modalStore';
-import { RpcError } from '@/types/errors';
+import { getErrorMessage, RpcError, RpcErrorMessage } from '@/types/errors';
 import { ResourceParams, SetPublicParams } from '@/types/shareOption';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -13,8 +13,8 @@ export const useSetPublic = ({ id, resourceType }: ResourceParams) => {
     mutationFn: async (params: SetPublicParams) => {
       const result = await setPublic(params);
 
-      if ('error' in result) {
-        throw new RpcError(result.error, result.code);
+      if (!result.success) {
+        throw new RpcError(result.error.message, result.error.code);
       }
 
       return result;
@@ -26,11 +26,17 @@ export const useSetPublic = ({ id, resourceType }: ResourceParams) => {
     },
     onError: (error) => {
       console.error('공개 여부 설정 실패: ', error.message);
+
+      const message =
+        error instanceof RpcError
+          ? getErrorMessage(error.message as RpcErrorMessage, '공개 여부 설정')
+          : getErrorMessage('INTERNAL_ERROR', '공개 여부 설정');
+
       open({
         type: 'error',
         props: {
           title: '공개 여부 설정 실패',
-          description: `${error.message}\n잠시 후 다시 시도해주세요.`,
+          description: `${message}\n잠시 후 다시 시도해주세요.`,
         },
       });
     },

--- a/hooks/shareOption/useSetPublic.ts
+++ b/hooks/shareOption/useSetPublic.ts
@@ -29,8 +29,8 @@ export const useSetPublic = ({ id, resourceType }: ResourceParams) => {
 
       const message =
         error instanceof RpcError
-          ? getErrorMessage(error.message as RpcErrorMessage, '공개 여부 설정')
-          : getErrorMessage('INTERNAL_ERROR', '공개 여부 설정');
+          ? getErrorMessage(error.message as RpcErrorMessage, { subject: '공개 여부', action: '설정' })
+          : getErrorMessage('INTERNAL_ERROR', { subject: '공개 여부', action: '설정' });
 
       open({
         type: 'error',

--- a/lib/actions/api/placeList.ts
+++ b/lib/actions/api/placeList.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { toCamelKey } from '@/lib/utils/toCamelCase';
 import type { Place, PageParam, AllPlaceLists, ListType, PlaceListDetail, Tag } from '@/types/placeList';
-import { RpcError } from '@/types/errors';
+import { RpcError, RpcErrorMessage } from '@/types/errors';
 
 interface GetPlaceListPlacesProps {
   supabase: SupabaseClient;
@@ -62,12 +62,13 @@ export const getPlaceListDetail = async ({
     p_list_id: listId,
   });
 
-  if (error) {
-    console.error('❌ 리스트 상세정보 조회 실패: ', error);
-    throw new RpcError(error.message, error.code);
+  if (error) throw new RpcError(error.message as RpcErrorMessage, error.code);
+
+  if (!data) {
+    console.error('❌ 리스트 상세정보 없음: ', listId);
+    throw new RpcError('NOT_FOUND');
   }
 
-  if (!data) throw new RpcError('장소 리스트 상세정보를 가져오는 데 실패했습니다.');
   return data;
 };
 
@@ -83,10 +84,11 @@ export const getPlaceListTags = async ({
     p_list_id: listId,
   });
 
-  if (error) {
-    console.error('❌ 태그 조회 실패', error);
-    throw new RpcError(error.message, error.code);
+  if (error) throw new RpcError(error.message as RpcErrorMessage, error.code);
+
+  if (!data) {
+    console.error('❌ 리스트 상세정보 없음: ', listId);
+    throw new RpcError('NOT_FOUND');
   }
-  if (!data) throw new RpcError('저장된 태그를 가져오는 데 실패했습니다.');
   return toCamelKey<Tag[]>(data);
 };

--- a/lib/actions/placeList.ts
+++ b/lib/actions/placeList.ts
@@ -2,7 +2,7 @@
 
 import { auth } from '../utils/auth';
 import { supabaseAdmin, supabaseUser } from '../utils/supabase';
-import { ActionResult, SQLSTATE_TO_RPC_ERROR } from '@/types/errors';
+import { ActionResult, isPostgresError, RpcErrorMessage, SQLSTATE_TO_RPC_ERROR } from '@/types/errors';
 
 export interface CreatePlaceListForm {
   title: string;
@@ -37,16 +37,23 @@ export const createNewPlaceList = async ({ title, icon, description }: CreatePla
 
 // 리스트 삭제
 export const deletePlaceList = async (listId: string): Promise<ActionResult<null>> => {
-  const supabase = await supabaseUser();
-  const { error } = await supabase.rpc('delete_place_list', {
-    p_list_id: listId,
-  });
+  try {
+    const supabase = await supabaseUser();
+    const { error } = await supabase.rpc('delete_place_list', {
+      p_list_id: listId,
+    });
 
-  if (error) {
+    if (error) {
+      console.error('❌ 리스트 삭제 실패: ', error);
+      const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
+      return { success: false, error: { message, code: error.code } };
+    }
+
+    return { success: true, data: null };
+  } catch (error: unknown) {
     console.error('❌ 리스트 삭제 실패: ', error);
-    const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
-    return { success: false, error: { message, code: error.code } };
+    const code = isPostgresError(error) ? error.code : undefined;
+    const message = ((code && SQLSTATE_TO_RPC_ERROR[code]) ?? 'INTERNAL_ERROR') as RpcErrorMessage;
+    return { success: false, error: { message, code } };
   }
-
-  return { success: true, data: null };
 };

--- a/lib/actions/placeList.ts
+++ b/lib/actions/placeList.ts
@@ -2,7 +2,7 @@
 
 import { auth } from '../utils/auth';
 import { supabaseAdmin, supabaseUser } from '../utils/supabase';
-import { ActionResult } from '@/types/errors';
+import { ActionResult, SQLSTATE_TO_RPC_ERROR } from '@/types/errors';
 
 export interface CreatePlaceListForm {
   title: string;
@@ -36,7 +36,7 @@ export const createNewPlaceList = async ({ title, icon, description }: CreatePla
 };
 
 // 리스트 삭제
-export const deletePlaceList = async (listId: string): Promise<ActionResult> => {
+export const deletePlaceList = async (listId: string): Promise<ActionResult<null>> => {
   const supabase = await supabaseUser();
   const { error } = await supabase.rpc('delete_place_list', {
     p_list_id: listId,
@@ -44,8 +44,9 @@ export const deletePlaceList = async (listId: string): Promise<ActionResult> => 
 
   if (error) {
     console.error('❌ 리스트 삭제 실패: ', error);
-    return { error: '장소 리스트 삭제 중 오류가 발생했습니다.', code: error.code };
+    const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
+    return { success: false, error: { message, code: error.code } };
   }
 
-  return { success: true };
+  return { success: true, data: null };
 };

--- a/lib/actions/shareOption.ts
+++ b/lib/actions/shareOption.ts
@@ -1,11 +1,15 @@
 'use server';
 
-import { ActionResult } from '@/types/errors';
+import { ActionResult, SQLSTATE_TO_RPC_ERROR } from '@/types/errors';
 import { supabaseUser } from '../utils/supabase';
 import { DeleteMemberParams, SetPublicParams } from '@/types/shareOption';
 
 // 참여 유저 삭제
-export const deleteMember = async ({ id, resourceType, targetUserId }: DeleteMemberParams): Promise<ActionResult> => {
+export const deleteMember = async ({
+  id,
+  resourceType,
+  targetUserId,
+}: DeleteMemberParams): Promise<ActionResult<null>> => {
   const supabase = await supabaseUser();
 
   const { error } = await supabase.rpc('delete_member', {
@@ -16,14 +20,15 @@ export const deleteMember = async ({ id, resourceType, targetUserId }: DeleteMem
 
   if (error) {
     console.error('❌ 참여 유저 삭제 실패:', error);
-    return { error: '참여 유저를 삭제하는 중 오류가 발생했습니다.', code: error.code };
+    const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
+    return { success: false, error: { message, code: error.code } };
   }
 
-  return { success: true };
+  return { success: true, data: null };
 };
 
 // 공개, 비공개 설정
-export const setPublic = async ({ id, resourceType, isPublic }: SetPublicParams): Promise<ActionResult> => {
+export const setPublic = async ({ id, resourceType, isPublic }: SetPublicParams): Promise<ActionResult<null>> => {
   const supabase = await supabaseUser();
 
   const { error } = await supabase.rpc('set_public', {
@@ -34,8 +39,9 @@ export const setPublic = async ({ id, resourceType, isPublic }: SetPublicParams)
 
   if (error) {
     console.error('❌ 공개/비공개 설정 실패:', error);
-    return { error: '공개 여부 설정중 오류가 발생했습니다.', code: error.code };
+    const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
+    return { success: false, error: { message, code: error.code } };
   }
 
-  return { success: true };
+  return { success: true, data: null };
 };

--- a/lib/actions/shareOption.ts
+++ b/lib/actions/shareOption.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { ActionResult, SQLSTATE_TO_RPC_ERROR } from '@/types/errors';
+import { ActionResult, isPostgresError, RpcErrorMessage, SQLSTATE_TO_RPC_ERROR } from '@/types/errors';
 import { supabaseUser } from '../utils/supabase';
 import { DeleteMemberParams, SetPublicParams } from '@/types/shareOption';
 
@@ -10,38 +10,52 @@ export const deleteMember = async ({
   resourceType,
   targetUserId,
 }: DeleteMemberParams): Promise<ActionResult<null>> => {
-  const supabase = await supabaseUser();
+  try {
+    const supabase = await supabaseUser();
 
-  const { error } = await supabase.rpc('delete_member', {
-    p_resource_id: id,
-    p_resource_type: resourceType,
-    p_target_user_id: targetUserId,
-  });
+    const { error } = await supabase.rpc('delete_member', {
+      p_resource_id: id,
+      p_resource_type: resourceType,
+      p_target_user_id: targetUserId,
+    });
 
-  if (error) {
-    console.error('❌ 참여 유저 삭제 실패:', error);
-    const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
-    return { success: false, error: { message, code: error.code } };
+    if (error) {
+      console.error('❌ 참여 유저 삭제 실패:', error);
+      const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
+      return { success: false, error: { message, code: error.code } };
+    }
+
+    return { success: true, data: null };
+  } catch (error: unknown) {
+    console.error('❌ 참여 유저 삭제 실패: ', error);
+    const code = isPostgresError(error) ? error.code : undefined;
+    const message = ((code && SQLSTATE_TO_RPC_ERROR[code]) ?? 'INTERNAL_ERROR') as RpcErrorMessage;
+    return { success: false, error: { message, code } };
   }
-
-  return { success: true, data: null };
 };
 
 // 공개, 비공개 설정
 export const setPublic = async ({ id, resourceType, isPublic }: SetPublicParams): Promise<ActionResult<null>> => {
-  const supabase = await supabaseUser();
+  try {
+    const supabase = await supabaseUser();
 
-  const { error } = await supabase.rpc('set_public', {
-    p_is_public: isPublic,
-    p_resource_id: id,
-    p_resource_type: resourceType,
-  });
+    const { error } = await supabase.rpc('set_public', {
+      p_is_public: isPublic,
+      p_resource_id: id,
+      p_resource_type: resourceType,
+    });
 
-  if (error) {
-    console.error('❌ 공개/비공개 설정 실패:', error);
-    const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
-    return { success: false, error: { message, code: error.code } };
+    if (error) {
+      console.error('❌ 공개/비공개 설정 실패: ', error);
+      const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
+      return { success: false, error: { message, code: error.code } };
+    }
+
+    return { success: true, data: null };
+  } catch (error: unknown) {
+    console.error('❌ 공개/비공개 설정 실패: ', error);
+    const code = isPostgresError(error) ? error.code : undefined;
+    const message = ((code && SQLSTATE_TO_RPC_ERROR[code]) ?? 'INTERNAL_ERROR') as RpcErrorMessage;
+    return { success: false, error: { message, code } };
   }
-
-  return { success: true, data: null };
 };

--- a/types/errors.ts
+++ b/types/errors.ts
@@ -23,6 +23,7 @@ export const SQLSTATE_TO_RPC_ERROR: Record<string, RpcErrorMessage> = {
   '23505': 'CONFLICT',
   P0002: 'NOT_FOUND',
   P0001: 'FORBIDDEN',
+  '23502': 'VALIDATION_ERROR',
   SELF1: 'CANNOT_REMOVE_SELF',
 };
 
@@ -41,14 +42,15 @@ export const RPC_ERROR_TO_STATUS: Record<RpcErrorMessage, number> = {
 export const ERROR_MESSAGES: Record<RpcErrorMessage, string> = {
   UNAUTHORIZED: '로그인이 필요합니다.',
   FORBIDDEN: '권한이 없습니다.',
-  NOT_FOUND: '을(를) 찾을 수 없습니다.',
+  NOT_FOUND: '대상을(를) 찾을 수 없습니다.',
   CONFLICT: '이(가) 이미 존재합니다.',
   VALIDATION_ERROR: '입력값을 확인해주세요.',
   INTERNAL_ERROR: '중 오류가 발생했습니다.',
   CANNOT_REMOVE_SELF: '자기 자신은 삭제할 수 없습니다.',
 };
 
-export const getErrorMessage = (message: RpcErrorMessage, subject: string) => `${subject} ${ERROR_MESSAGES[message]}`;
+export const getErrorMessage = (message: RpcErrorMessage, subject: string): string =>
+  `${subject} ${ERROR_MESSAGES[message]}`;
 
 // 조회 함수에서 사용하는 에러 클래스
 export class RpcError extends Error {

--- a/types/errors.ts
+++ b/types/errors.ts
@@ -49,8 +49,26 @@ export const ERROR_MESSAGES: Record<RpcErrorMessage, string> = {
   CANNOT_REMOVE_SELF: '자기 자신은 삭제할 수 없습니다.',
 };
 
-export const getErrorMessage = (message: RpcErrorMessage, subject: string): string =>
-  `${subject} ${ERROR_MESSAGES[message]}`;
+export function getErrorMessage(code: RpcErrorMessage, { action, subject }: { action: string; subject: string }) {
+  switch (code) {
+    case 'INTERNAL_ERROR':
+      return `${subject} ${action} 중 오류가 발생했습니다.`;
+    case 'NOT_FOUND':
+      return `${subject}을(를) 찾을 수 없습니다.`;
+    case 'CONFLICT':
+      return `${subject}이(가) 이미 존재합니다.`;
+    case 'UNAUTHORIZED':
+      return '로그인이 필요합니다.';
+    case 'FORBIDDEN':
+      return '권한이 없습니다.';
+    case 'VALIDATION_ERROR':
+      return '입력값을 확인해주세요.';
+    case 'CANNOT_REMOVE_SELF':
+      return '자기 자신은 삭제할 수 없습니다.';
+    default:
+      return '알 수 없는 오류가 발생했습니다.';
+  }
+}
 
 // 조회 함수에서 사용하는 에러 클래스
 export class RpcError extends Error {

--- a/types/errors.ts
+++ b/types/errors.ts
@@ -70,3 +70,9 @@ export type ActionResult<T> =
 export function isPostgresError(error: unknown): error is { code: string; message: string } {
   return typeof error === 'object' && error !== null && 'code' in error;
 }
+
+// 조회 함수 Router Handler 응답타입
+export interface RpcErrorResponseBody {
+  error: RpcErrorMessage;
+  code?: string;
+}

--- a/types/errors.ts
+++ b/types/errors.ts
@@ -8,18 +8,65 @@ export class AuthError extends Error {
   }
 }
 
-// 조회 함수용 에러 클래스 (throw)
-// DB/RPC에서 온 에러 코드를 UI에 전달할 때 사용
+export type RpcErrorMessage =
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'VALIDATION_ERROR'
+  | 'CANNOT_REMOVE_SELF'
+  | 'INTERNAL_ERROR';
+
+// SQLSTATE → RpcErrorMessage
+export const SQLSTATE_TO_RPC_ERROR: Record<string, RpcErrorMessage> = {
+  '42501': 'UNAUTHORIZED',
+  '23505': 'CONFLICT',
+  P0002: 'NOT_FOUND',
+  P0001: 'FORBIDDEN',
+  SELF1: 'CANNOT_REMOVE_SELF',
+};
+
+// RpcErrorMessage → HTTP status
+export const RPC_ERROR_TO_STATUS: Record<RpcErrorMessage, number> = {
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  VALIDATION_ERROR: 422,
+  INTERNAL_ERROR: 500,
+  CANNOT_REMOVE_SELF: 409,
+};
+
+// 에러 메시지 템플릿
+export const ERROR_MESSAGES: Record<RpcErrorMessage, string> = {
+  UNAUTHORIZED: '로그인이 필요합니다.',
+  FORBIDDEN: '권한이 없습니다.',
+  NOT_FOUND: '을(를) 찾을 수 없습니다.',
+  CONFLICT: '이(가) 이미 존재합니다.',
+  VALIDATION_ERROR: '입력값을 확인해주세요.',
+  INTERNAL_ERROR: '중 오류가 발생했습니다.',
+  CANNOT_REMOVE_SELF: '자기 자신은 삭제할 수 없습니다.',
+};
+
+export const getErrorMessage = (message: RpcErrorMessage, subject: string) => `${subject} ${ERROR_MESSAGES[message]}`;
+
+// 조회 함수에서 사용하는 에러 클래스
 export class RpcError extends Error {
   code?: string;
-
-  constructor(message: string, code?: string) {
+  constructor(message: RpcErrorMessage, code?: string) {
     super(message);
     this.name = 'RpcError';
     this.code = code;
+    Object.setPrototypeOf(this, RpcError.prototype);
   }
 }
 
-// 서버 액션용 결과 타입 (return)
-// 서버 액션('use server') 에러는 훅에서 잡아내지 못하기 때문에 RpcError 클래스가 아닌 해당 타입 사용 필요
-export type ActionResult<T = { success: true }> = T | { error: string; code?: string };
+// 서버 액션('use server')에서 사용하는 반환 타입
+export type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: { message: RpcErrorMessage; code?: string } };
+
+// 타입가드
+export function isPostgresError(error: unknown): error is { code: string; message: string } {
+  return typeof error === 'object' && error !== null && 'code' in error;
+}


### PR DESCRIPTION
## 🛠️ 과제 요약

- 회의에서 논의했던 새로운 에러 타입 적용 ([참고 문서](https://app.notion.com/p/3a6726cada0880f2b21cfadc8bcf8c41?source=copy_link))

## 📝 요구 사항과 구현 내용
#### 1️⃣  새로운 에러 타입 및 수정된 에러 클래스 적용(`error.ts`)
#### 2️⃣ Queryboundary가 subject를 받을 수 있게 수정
#### 3️⃣ 이전 pr에서 수정 전 RpcError를 사용하고 있던 장소 리스트 관련 코드 수정
#### 4️⃣ 권한 검증 로직 관련 서버 컴포넌트 코드 수정
```typescript
if (error instanceof RpcError && error.message === 'FORBIDDEN') {
      return <ForbiddenRedirect />;
    }
```
- 이리저리 바꿔서 혼란스러우시죱... 새로운 컨벤션을 적용하면서 에러코드로 따지는 것보다는 메세지로 검증하는 편이 추후 에러코드가 바뀌어도 변경 없이 적용될 수 있을 것 같아 위와 같이 다시 수정했습니다 참고 부탁드려요!

## 💬 PR 포인트 & 궁금한 점

#### Router Handler 를 fetch하는 패턴 추가
```typescript
// RpcErrorResponseBody 타입 추가
// 조회 함수 Router Handler 응답타입
export interface RpcErrorResponseBody {
  error: RpcErrorMessage;
  code?: string;
}

// queryFn에 사용할 fetch 함수에서 처리
const fetchPlaceListDetail = async (listId: string): Promise<PlaceListDetail> => {
  const res = await fetch(`/api/view/place-list/${listId}/detail`);
  if (!res.ok) {
    const body = (await res.json().catch(() => null)) as RpcErrorResponseBody | null; // 여기서 사용할 타입 추가
    const message: RpcErrorMessage = body?.error ?? 'INTERNAL_ERROR';
    throw new RpcError(message);
  }
  return res.json();
};
```
회의에서 자세하게 작성되지 않았던 이 부분만 새로 추가했습니다! 노션 문서에도 정리되어 있습니다


- 아래 사진처럼 잘 뜨긴 하는데 에러 문구...? 를 좀 수정해야 하나 싶기도 하네요 getErrorMessage로 조합할 때 문장이 이상해지는 경우가 있는 것 같아서..! 참고 부탁드립니다.
<img width="350" alt="스크린샷 2026-07-24 오전 5 06 18" src="https://github.com/user-attachments/assets/f17cb8fc-db06-4f66-8b0e-2e19fead3e1d" />
<img width="350" alt="스크린샷 2026-07-24 오전 5 07 26" src="https://github.com/user-attachments/assets/65ab82bc-89de-42be-86c6-24b388fd944a" />

## 🧪 테스트 방법
서버 액션, 조회 함수에서 에러 던지면서 테스트해보기