### PR TITLE
[L_006, L_011] 지도 제외한 장소 리스트 미구현 기능 적용

### DIFF
--- a/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
+++ b/app/(lobby)/places/(with-pattern)/[listId]/page.tsx
@@ -1,8 +1,6 @@
-import TagList from '@/components/features/place-list/tag/TagList';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import PlaceListHeader from '@/components/features/place-list/detail/PlaceListHeader';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
-import PlaceListPlaces from '@/components/features/place-list/detail/PlaceListPlaces';
 import InviteEditorHandler from '@/components/features/invite/InviteEditorHandler';
 import { prefetchPlaceListDetail } from '@/lib/actions/api/prefetch/prefetchPlaceListDetail';
 import { Suspense } from 'react';
@@ -14,6 +12,7 @@ import { handleInviteAccess } from '@/lib/utils/invite/handleInviteAcess';
 import { getPlaceListDetail } from '@/lib/actions/api/placeList';
 import { supabaseUser } from '@/lib/utils/supabase';
 import { RpcError } from '@/types/errors';
+import PlaceListContent from '@/components/features/place-list/detail/PlaceListContent';
 
 export default async function PlaceListDetail({
   params,
@@ -63,14 +62,7 @@ export default async function PlaceListDetail({
           />
         </QueryBoundary>
 
-        <div className='flex flex-col gap-3'>
-          <QueryBoundary subject='태그'>
-            <TagList listId={listId} />
-          </QueryBoundary>
-          <QueryBoundary subject='저장된 장소'>
-            <PlaceListPlaces listId={listId} />
-          </QueryBoundary>
-        </div>
+        <PlaceListContent listId={listId} />
       </div>
     </HydrationBoundary>
   );

--- a/app/api/view/place-list/[listId]/places/route.ts
+++ b/app/api/view/place-list/[listId]/places/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseUser } from '@/lib/utils/supabase';
 import { getPlaceListPlaces } from '@/lib/actions/api/placeList';
+import { SortType } from '@/types/placeList';
+import { RPC_ERROR_TO_STATUS, RpcError, RpcErrorMessage } from '@/types/errors';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ listId: string }> }) {
   const { listId } = await params;
   const searchParams = request.nextUrl.searchParams;
   const createdAt = searchParams.get('createdAt');
   const cursorId = searchParams.get('id');
+  const sortBy = (searchParams.get('sortBy') as SortType) ?? 'created_desc';
 
   const supabase = await supabaseUser();
 
@@ -14,11 +17,20 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const data = await getPlaceListPlaces({
       supabase,
       listId,
+      sortBy,
       cursor: createdAt && cursorId ? { createdAt, id: cursorId } : null,
     });
     return NextResponse.json(data);
-  } catch (error: any) {
-    console.error('❌ place-list places 에러:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+  } catch (error: unknown) {
+    console.error('❌ 저장된 장소 조회 실패:', error);
+
+    if (error instanceof RpcError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: RPC_ERROR_TO_STATUS[error.message as RpcErrorMessage] ?? 500 },
+      );
+    }
+
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 });
   }
 }

--- a/components/common/Dropdown/Item.tsx
+++ b/components/common/Dropdown/Item.tsx
@@ -1,23 +1,35 @@
+import { HTMLAttributes } from 'react';
 import { useDropdown } from './DropdownContext';
 
-interface DropDownItemProps {
-  children: React.ReactNode;
-  onClick?: () => void;
+interface DropDownItemProps extends HTMLAttributes<HTMLDivElement> {
+  isSelected?: boolean;
   disabled?: boolean;
+  size?: 'normal' | 'mini';
 }
 
-export default function DropDownItem({ children, onClick, disabled = false }: DropDownItemProps) {
+export default function DropDownItem({
+  children,
+  onClick,
+  disabled = false,
+  size = 'normal',
+  className = '',
+  isSelected = false,
+  ...props
+}: DropDownItemProps) {
   const { close } = useDropdown();
 
-  const handleClick = () => {
+  const sizeClasses = size === 'mini' ? 'px-[7.5px] py-1 text-typo-description' : 'px-5 py-2 text-typo-base';
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (disabled) return;
     close();
-    onClick?.();
+    onClick?.(e);
   };
 
   return (
     <div
-      className='w-full text-typo-base font-light text-left text-brand-gray-700 cursor-pointer hover:bg-brand-gray-100 rounded-lg px-5 py-2 '
+      {...props}
+      className={`w-full font-light text-left text-brand-gray-700 cursor-pointer hover:bg-brand-gray-100 rounded-lg ${sizeClasses} ${className} ${isSelected ? 'text-brand-gray-600 font-medium' : ''}`}
       onClick={handleClick}
     >
       {children}

--- a/components/common/Dropdown/Menu.tsx
+++ b/components/common/Dropdown/Menu.tsx
@@ -5,9 +5,10 @@ import { useDropdown } from './DropdownContext';
 
 interface DropDownMenuProps {
   children: React.ReactNode;
+  minWidth?: boolean;
 }
 
-export default function DropDownMenu({ children }: DropDownMenuProps) {
+export default function DropDownMenu({ children, minWidth = true }: DropDownMenuProps) {
   const { isOpen, setFloating, floatingStyles, getFloatingProps } = useDropdown();
 
   if (!isOpen) return null;
@@ -16,7 +17,7 @@ export default function DropDownMenu({ children }: DropDownMenuProps) {
     <div
       ref={setFloating}
       style={floatingStyles}
-      className='flex flex-col bg-white rounded-lg shadow-md min-w-60.25 z-100 p-2 gap-1'
+      className={`flex flex-col bg-white rounded-lg shadow-md ${minWidth ? 'min-w-60.25' : ''} z-100 p-2 gap-1`}
       {...getFloatingProps()}
     >
       {children}

--- a/components/common/Dropdown/Trigger.tsx
+++ b/components/common/Dropdown/Trigger.tsx
@@ -1,16 +1,17 @@
+import { ButtonHTMLAttributes } from 'react';
 import { useDropdown } from './DropdownContext';
 
-interface DropDownTriggerProps {
+interface DropDownTriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
 }
 
-export default function DropDownTrigger({ children }: DropDownTriggerProps) {
+export default function DropDownTrigger({ children, className = '', ...props }: DropDownTriggerProps) {
   const { setReference, getReferenceProps } = useDropdown();
   return (
     <button
       ref={setReference}
-      {...getReferenceProps()}
-      className='cursor-pointer'
+      {...getReferenceProps(props)}
+      className={`cursor-pointer ${className}`.trim()}
     >
       {children}
     </button>

--- a/components/common/Dropdown/index.tsx
+++ b/components/common/Dropdown/index.tsx
@@ -8,15 +8,16 @@ import { flip, offset, Placement, shift, useClick, useDismiss, useFloating, useI
 interface DropDownProps {
   children: React.ReactNode;
   placement?: Placement;
+  offsetValue?: number;
 }
 
-export default function DropDown({ children, placement = 'right-start' }: DropDownProps) {
+export default function DropDown({ children, placement = 'right-start', offsetValue = 18 }: DropDownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const { refs, floatingStyles, context } = useFloating({
     open: isOpen,
     onOpenChange: setIsOpen,
     placement: placement,
-    middleware: [offset(18), flip(), shift()],
+    middleware: [offset(offsetValue), flip(), shift()],
   });
 
   const click = useClick(context);

--- a/components/common/EmptyState.tsx
+++ b/components/common/EmptyState.tsx
@@ -1,3 +1,3 @@
 export default function EmptyState({ message }: { message: string }) {
-  return <div className='w-full text-center py-7 text-brand-gray-400 text-typo-base'>{message}</div>;
+  return <div className='w-full font-light text-center py-7 text-brand-gray-400 text-typo-base'>{message}</div>;
 }

--- a/components/common/ShareLinkModal.tsx
+++ b/components/common/ShareLinkModal.tsx
@@ -48,7 +48,8 @@ export default function ShareLinkModal({ type, link }: { type: ShareType; link: 
           <input
             className='modal-input min-w-0'
             value={link}
-            disabled
+            readOnly
+            onClick={(e) => e.currentTarget.select()}
           />
           <button
             className='modal-button px-5 shrink-0 min-w-30.25'

--- a/components/features/Place/save/ListModal.tsx
+++ b/components/features/Place/save/ListModal.tsx
@@ -130,7 +130,7 @@ export default function SaveToListModal({ placeDetail, onClose, onCreateNewList 
                   {isAlreadySaved && <span className='ml-1 text-typo-caption text-brand-gray-400'>저장됨</span>}
                 </p>
                 <p className='text-typo-caption text-brand-gray-500'>
-                  {list.isPublic ? '공유됨' : '비공개'}
+                  {list.isPublic ? '공개됨' : '비공개'}
                   {list.placeCount > 0 && ` · ${list.placeCount}개 장소`}
                 </p>
               </button>

--- a/components/features/place-list/detail/ParticipantsImages.tsx
+++ b/components/features/place-list/detail/ParticipantsImages.tsx
@@ -29,7 +29,7 @@ export default function ParticipantsImages({
 
       {remainingCount > 0 && (
         <div
-          className='-ml-0.5 flex h-5 w-5 items-center justify-center text-typo-base text-[##F4F4F5] font-light'
+          className='-ml-0.5 flex h-5 w-5 items-center justify-center text-typo-description text-[##F4F4F5] font-light'
           style={{ zIndex: 0 }}
         >
           +{remainingCount}

--- a/components/features/place-list/detail/ParticipantsImages.tsx
+++ b/components/features/place-list/detail/ParticipantsImages.tsx
@@ -1,19 +1,40 @@
 import { MemberAvatar } from '@/components/common/ShareOption/MemberAvatar';
 import { PlaceListMember } from '@/types/placeList';
 
-export default function ParticipantsImages({ data }: { data: PlaceListMember[] }) {
+export default function ParticipantsImages({
+  data,
+  participantCount,
+}: {
+  data: PlaceListMember[];
+  participantCount: number;
+}) {
+  const remainingCount = Math.max(0, participantCount - data.length);
+
   return (
-    <>
+    <div className='flex items-center'>
       {data &&
-        data.map((user) => (
-          <div key={user.id}>
+        data.map((user, index) => (
+          <div
+            key={user.id}
+            className={`border-2 border-[#EBF1E5] rounded-full ${index !== 0 ? '-ml-1.5' : ''}`}
+            style={{ zIndex: data.length - index }}
+          >
             <MemberAvatar
-              name={user.username}
-              profileImage={user.profileImage}
-              size={24}
+              name={''}
+              profileImage={user.profileImageUrl}
+              size={20}
             />
           </div>
         ))}
-    </>
+
+      {remainingCount > 0 && (
+        <div
+          className='-ml-0.5 flex h-5 w-5 items-center justify-center text-typo-base text-[##F4F4F5] font-light'
+          style={{ zIndex: 0 }}
+        >
+          +{remainingCount}
+        </div>
+      )}
+    </div>
   );
 }

--- a/components/features/place-list/detail/ParticipantsImages.tsx
+++ b/components/features/place-list/detail/ParticipantsImages.tsx
@@ -1,0 +1,19 @@
+import { MemberAvatar } from '@/components/common/ShareOption/MemberAvatar';
+import { PlaceListMember } from '@/types/placeList';
+
+export default function ParticipantsImages({ data }: { data: PlaceListMember[] }) {
+  return (
+    <>
+      {data &&
+        data.map((user) => (
+          <div key={user.id}>
+            <MemberAvatar
+              name={user.username}
+              profileImage={user.profileImage}
+              size={24}
+            />
+          </div>
+        ))}
+    </>
+  );
+}

--- a/components/features/place-list/detail/PlaceItem.tsx
+++ b/components/features/place-list/detail/PlaceItem.tsx
@@ -6,10 +6,12 @@ import Image from 'next/image';
 import React, { useState } from 'react';
 import PlaceTag from '../tag/PlaceTag';
 import { getPlaceCategoryLabel } from '@/lib/utils/categoryLabel';
+import { useConfirmDeletePlace } from '@/hooks/place-list/useConfirmDeletePlace';
 
-export default function PlaceItem({ place }: { place: Place }) {
+export default function PlaceItem({ place, listId }: { place: Place; listId: string }) {
   const [isEdit, setIsEdit] = useState(false);
   const [memo, setMemo] = useState<string | null>(place.memoContent);
+  const { confirmDeletePlaceList } = useConfirmDeletePlace(listId);
 
   const handleEdit = (e: React.SubmitEvent) => {
     e.preventDefault();
@@ -34,12 +36,21 @@ export default function PlaceItem({ place }: { place: Place }) {
       <div className='flex flex-col gap-1 flex-1'>
         <div className='flex justify-between items-center'>
           <p className='flex-1 text-typo-sub-title text-brand-gray-600 font-medium'>{place.customName}</p>
-          <Icon
-            name={isEdit ? 'XClose' : 'Edit'}
-            size={26}
-            className={`cursor-pointer ${isEdit ? 'text-brand-gray-400' : 'text-brand-gray-300'}`}
-            onClick={() => setIsEdit(!isEdit)}
-          />
+          {isEdit ? (
+            <Icon
+              name='XClose'
+              size={26}
+              className='cursor-pointer text-brand-gray-400'
+              onClick={() => confirmDeletePlaceList(place.customName, place.id)}
+            />
+          ) : (
+            <Icon
+              name={'Edit'}
+              size={26}
+              className='cursor-pointer text-brand-gray-300'
+              onClick={() => setIsEdit(!isEdit)}
+            />
+          )}
         </div>
 
         {!isEdit && place.category && (

--- a/components/features/place-list/detail/PlaceItem.tsx
+++ b/components/features/place-list/detail/PlaceItem.tsx
@@ -8,11 +8,14 @@ import PlaceTag from '../tag/PlaceTag';
 import { getPlaceCategoryLabel } from '@/lib/utils/categoryLabel';
 import { useConfirmDeletePlace } from '@/hooks/place-list/useConfirmDeletePlace';
 import { useUpdatePlace } from '@/hooks/place-list/useUpdatePlace';
+import AuthorityWrapper from '../../AuthorityWrapper';
+import { useGetMyRole } from '@/hooks/place-list/useGetMyRole';
 
 export default function PlaceItem({ place, listId }: { place: Place; listId: string }) {
   const [isEdit, setIsEdit] = useState(false);
   const [memo, setMemo] = useState<string | null>(place.memoContent);
   const { confirmDeletePlaceList } = useConfirmDeletePlace(listId);
+  const { data: myRole } = useGetMyRole(listId);
   const { mutate: updatePlace } = useUpdatePlace(listId);
 
   const handleEdit = () => {
@@ -44,12 +47,17 @@ export default function PlaceItem({ place, listId }: { place: Place; listId: str
               onClick={() => confirmDeletePlaceList(place.customName, place.id)}
             />
           ) : (
-            <Icon
-              name={'Edit'}
-              size={26}
-              className='cursor-pointer text-brand-gray-300'
-              onClick={() => setIsEdit(!isEdit)}
-            />
+            <AuthorityWrapper
+              role={myRole}
+              requiredRole='editor'
+            >
+              <Icon
+                name={'Edit'}
+                size={26}
+                className='cursor-pointer text-brand-gray-300'
+                onClick={() => setIsEdit(!isEdit)}
+              />
+            </AuthorityWrapper>
           )}
         </div>
 

--- a/components/features/place-list/detail/PlaceItem.tsx
+++ b/components/features/place-list/detail/PlaceItem.tsx
@@ -31,22 +31,23 @@ export default function PlaceItem({ place, listId }: { place: Place; listId: str
             alt={place.thumbnail ? 'thumbnail' : 'not-found'}
             width={80}
             height={80}
-            className='w-full h-full object-cover'
+            className='w-full h-full object-cover rounded-xs'
           />
         </div>
       )}
 
       <div className='flex flex-col gap-1 flex-1'>
         <div className='flex justify-between items-center'>
-          <p className='flex-1 text-typo-sub-title text-brand-gray-600 font-medium'>{place.customName}</p>
-          {isEdit ? (
+          {isEdit && (
             <Icon
               name='XClose'
               size={26}
-              className='cursor-pointer text-brand-gray-400'
+              className='cursor-pointer text-brand-gray-400 mr-0.5'
               onClick={() => confirmDeletePlaceList(place.customName, place.id)}
             />
-          ) : (
+          )}
+          <p className='flex-1 text-typo-sub-title text-brand-gray-600 font-medium'>{place.customName}</p>
+          {!isEdit && (
             <AuthorityWrapper
               role={myRole}
               requiredRole='editor'
@@ -66,7 +67,9 @@ export default function PlaceItem({ place, listId }: { place: Place; listId: str
         )}
         {!isEdit ? (
           <>
-            {place.memoContent && <p className='text-brand-gray-600 text-typo-description'>{place.memoContent}</p>}
+            {place.memoContent && (
+              <p className='text-brand-gray-600 text-typo-description whitespace-pre-wrap'>{place.memoContent}</p>
+            )}
 
             {/* TODO: 2차 MVP 때 태그 적용 */}
             {/* <div className='flex gap-1 items-center overflow flex-wrap'>
@@ -83,7 +86,7 @@ export default function PlaceItem({ place, listId }: { place: Place; listId: str
           <div>
             <textarea
               value={memo ?? ''}
-              className='bg-brand-gray-100 min-h-16 text-typo-base px-3 py-2 text-brand-gray-600 border border-brand-gray-200 outline-none resize-none rounded-sm w-full overscroll-none'
+              className='bg-brand-gray-100 min-h-16 text-typo-base px-3 py-2 text-brand-gray-600 border border-brand-gray-200 outline-none rounded-sm w-full overscroll-none resize-y'
               onChange={(e) => setMemo(e.target.value)}
             />
 

--- a/components/features/place-list/detail/PlaceItem.tsx
+++ b/components/features/place-list/detail/PlaceItem.tsx
@@ -7,16 +7,16 @@ import React, { useState } from 'react';
 import PlaceTag from '../tag/PlaceTag';
 import { getPlaceCategoryLabel } from '@/lib/utils/categoryLabel';
 import { useConfirmDeletePlace } from '@/hooks/place-list/useConfirmDeletePlace';
+import { useUpdatePlace } from '@/hooks/place-list/useUpdatePlace';
 
 export default function PlaceItem({ place, listId }: { place: Place; listId: string }) {
   const [isEdit, setIsEdit] = useState(false);
   const [memo, setMemo] = useState<string | null>(place.memoContent);
   const { confirmDeletePlaceList } = useConfirmDeletePlace(listId);
+  const { mutate: updatePlace } = useUpdatePlace(listId);
 
-  const handleEdit = (e: React.SubmitEvent) => {
-    e.preventDefault();
-
-    // 수정 api 호출
+  const handleEdit = () => {
+    updatePlace({ placeId: place.id, memo }, { onSuccess: () => setIsEdit(false) });
   };
 
   return (
@@ -71,7 +71,7 @@ export default function PlaceItem({ place, listId }: { place: Place; listId: str
             </div>
           </>
         ) : (
-          <form>
+          <div>
             <textarea
               value={memo ?? ''}
               className='bg-brand-gray-100 min-h-16 text-typo-base px-3 py-2 text-brand-gray-600 border border-brand-gray-200 outline-none resize-none rounded-sm w-full'
@@ -86,13 +86,13 @@ export default function PlaceItem({ place, listId }: { place: Place; listId: str
                 취소
               </button>
               <button
-                type='submit'
                 className='flex-1 bg-brand-blue-700 text-brand-gray-0 rounded-sm py-2 cursor-pointer'
+                onClick={handleEdit}
               >
                 저장하기
               </button>
             </div>
-          </form>
+          </div>
         )}
       </div>
     </div>

--- a/components/features/place-list/detail/PlaceItem.tsx
+++ b/components/features/place-list/detail/PlaceItem.tsx
@@ -3,7 +3,7 @@
 import { Icon } from '@/components/common/Icon';
 import { Place } from '@/types/placeList';
 import Image from 'next/image';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PlaceTag from '../tag/PlaceTag';
 import { getPlaceCategoryLabel } from '@/lib/utils/categoryLabel';
 import { useConfirmDeletePlace } from '@/hooks/place-list/useConfirmDeletePlace';
@@ -58,9 +58,10 @@ export default function PlaceItem({ place, listId }: { place: Place; listId: str
         )}
         {!isEdit ? (
           <>
-            <p className='text-brand-gray-600 text-typo-description mb-1'>{place.memoContent}</p>
+            {place.memoContent && <p className='text-brand-gray-600 text-typo-description'>{place.memoContent}</p>}
 
-            <div className='flex gap-1 items-center overflow flex-wrap'>
+            {/* TODO: 2차 MVP 때 태그 적용 */}
+            {/* <div className='flex gap-1 items-center overflow flex-wrap'>
               {place.tags.map((item) => (
                 <PlaceTag
                   key={item.id}
@@ -68,13 +69,13 @@ export default function PlaceItem({ place, listId }: { place: Place; listId: str
                   isRounded={true}
                 />
               ))}
-            </div>
+            </div> */}
           </>
         ) : (
           <div>
             <textarea
               value={memo ?? ''}
-              className='bg-brand-gray-100 min-h-16 text-typo-base px-3 py-2 text-brand-gray-600 border border-brand-gray-200 outline-none resize-none rounded-sm w-full'
+              className='bg-brand-gray-100 min-h-16 text-typo-base px-3 py-2 text-brand-gray-600 border border-brand-gray-200 outline-none resize-none rounded-sm w-full overscroll-none'
               onChange={(e) => setMemo(e.target.value)}
             />
 

--- a/components/features/place-list/detail/PlaceItem.tsx
+++ b/components/features/place-list/detail/PlaceItem.tsx
@@ -20,38 +20,26 @@ export default function PlaceItem({ place }: { place: Place }) {
   return (
     <div className='w-full flex gap-3.25 bg-brand-gray-0 p-3 rounded-sm border border-brand-blue-700 items-start'>
       {!isEdit && (
-        <div className='w-20 h-20 shrink-0 border border-brand-blue-700 rounded-xs bg-brand-blue-50'>
-          {place.thumbnail ? (
-            <Image
-              src={place.thumbnail}
-              alt='thumbnail'
-              width={80}
-              height={80}
-            />
-          ) : (
-            <div>이미지</div>
-          )}
+        <div className='w-20 h-20 shrink-0 border border-brand-gray-200 rounded-xs bg-brand-blue-50'>
+          <Image
+            src={place.thumbnail || '/images/not-found.webp'}
+            alt={place.thumbnail ? 'thumbnail' : 'not-found'}
+            width={80}
+            height={80}
+            className='w-full h-full object-cover'
+          />
         </div>
       )}
 
       <div className='flex flex-col gap-1 flex-1'>
         <div className='flex justify-between items-center'>
-          <p className='flex-1 text-typo-sub-title text-brand-blue-700'>{place.customName}</p>
-          {!isEdit ? (
-            <Icon
-              name='Edit'
-              size={26}
-              className='text-brand-gray-300 cursor-pointer'
-              onClick={() => setIsEdit(!isEdit)}
-            />
-          ) : (
-            <Icon
-              name='XClose'
-              size={26}
-              className='text-brand-gray-400 cursor-pointer'
-              onClick={() => setIsEdit(!isEdit)}
-            />
-          )}
+          <p className='flex-1 text-typo-sub-title text-brand-gray-600 font-medium'>{place.customName}</p>
+          <Icon
+            name={isEdit ? 'XClose' : 'Edit'}
+            size={26}
+            className={`cursor-pointer ${isEdit ? 'text-brand-gray-400' : 'text-brand-gray-300'}`}
+            onClick={() => setIsEdit(!isEdit)}
+          />
         </div>
 
         {!isEdit && place.category && (

--- a/components/features/place-list/detail/PlaceListContent.tsx
+++ b/components/features/place-list/detail/PlaceListContent.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
+import TagList from '../tag/TagList';
+import PlaceListPlaces from './PlaceListPlaces';
+import { SortType } from '@/types/placeList';
+import { useState } from 'react';
+import SortingDropdownButton from './SortingDropdownButton';
+
+export default function PlaceListContent({ listId }: { listId: string }) {
+  const [sortBy, setSortBy] = useState<SortType>('createdDesc');
+  return (
+    <div className='flex flex-col gap-3'>
+      <div className='flex gap-2 text-typo-description items-center'>
+        {/* 장소 정렬 버튼 */}
+        <SortingDropdownButton
+          sortBy={sortBy}
+          onSortChange={setSortBy}
+        />
+        <QueryBoundary subject='태그'>
+          <TagList listId={listId} />
+        </QueryBoundary>
+      </div>
+      <QueryBoundary subject='저장된 장소'>
+        <PlaceListPlaces
+          listId={listId}
+          sortBy={sortBy}
+        />
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/components/features/place-list/detail/PlaceListContent.tsx
+++ b/components/features/place-list/detail/PlaceListContent.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import SortingDropdownButton from './SortingDropdownButton';
 
 export default function PlaceListContent({ listId }: { listId: string }) {
-  const [sortBy, setSortBy] = useState<SortType>('createdDesc');
+  const [sortBy, setSortBy] = useState<SortType>('created_desc');
   return (
     <div className='flex flex-col gap-3'>
       <div className='flex gap-2 text-typo-description items-center'>
@@ -17,9 +17,9 @@ export default function PlaceListContent({ listId }: { listId: string }) {
           sortBy={sortBy}
           onSortChange={setSortBy}
         />
-        <QueryBoundary subject='태그'>
+        {/* <QueryBoundary subject='태그'>
           <TagList listId={listId} />
-        </QueryBoundary>
+        </QueryBoundary> */}
       </div>
       <QueryBoundary subject='저장된 장소'>
         <PlaceListPlaces

--- a/components/features/place-list/detail/PlaceListHeader.tsx
+++ b/components/features/place-list/detail/PlaceListHeader.tsx
@@ -3,14 +3,19 @@
 import { Icon } from '@/components/common/Icon';
 import PlaceListDropdownMenu from '../PlaceListDropdwonMenu';
 import { useGetPlaceListDetail } from '@/hooks/place-list/useGetPlaceListDetail';
+import { useModalStore } from '@/lib/store/modalStore';
+import { createViewLink } from '@/lib/utils/invite/createViewLink';
+import { MemberAvatar } from '@/components/common/ShareOption/MemberAvatar';
+import ParticipantsImages from './ParticipantsImages';
 
 export default function PlaceListHeader({ listId, hasSession }: { listId: string; hasSession: boolean }) {
   const { data } = useGetPlaceListDetail(listId);
+  const { open } = useModalStore();
 
   return (
     <header className='flex flex-col gap-4'>
       <div className='flex items-start gap-3'>
-        <span className='font-mona12 text-typo-big-title'>{data.icon}</span>
+        {data.icon && <span className='font-mona12 text-typo-big-title'>{data.icon}</span>}
         <p className='font-semibold flex-1 text-typo-big-title text-brand-blue-700'>{data.title}</p>
 
         <div className='flex gap-3 mt-0.5'>
@@ -18,6 +23,9 @@ export default function PlaceListHeader({ listId, hasSession }: { listId: string
             name='Share'
             size={32}
             className='cursor-pointer'
+            onClick={() =>
+              open({ type: 'shareLink', props: { type: 'VIEW', link: createViewLink(listId, 'place_list') } })
+            }
           />
           {hasSession && (
             <PlaceListDropdownMenu
@@ -33,7 +41,7 @@ export default function PlaceListHeader({ listId, hasSession }: { listId: string
       <div className='flex flex-col gap-1 text-typo-base font-light'>
         <div className='flex gap-3 text-brand-gray-400'>
           <span>{data.master.username}</span>
-          {data.participantCount > 0 && <span>이미지</span>}
+          <ParticipantsImages data={data.participants} />
           <span>장소 {data.placeCount}개</span>
           <span>{data.isPublic ? '공유됨' : '비공개'}</span>
         </div>

--- a/components/features/place-list/detail/PlaceListHeader.tsx
+++ b/components/features/place-list/detail/PlaceListHeader.tsx
@@ -5,7 +5,6 @@ import PlaceListDropdownMenu from '../PlaceListDropdwonMenu';
 import { useGetPlaceListDetail } from '@/hooks/place-list/useGetPlaceListDetail';
 import { useModalStore } from '@/lib/store/modalStore';
 import { createViewLink } from '@/lib/utils/invite/createViewLink';
-import { MemberAvatar } from '@/components/common/ShareOption/MemberAvatar';
 import ParticipantsImages from './ParticipantsImages';
 
 export default function PlaceListHeader({ listId, hasSession }: { listId: string; hasSession: boolean }) {
@@ -39,9 +38,14 @@ export default function PlaceListHeader({ listId, hasSession }: { listId: string
       </div>
 
       <div className='flex flex-col gap-1 text-typo-base font-light'>
-        <div className='flex gap-3 text-brand-gray-400'>
+        <div className='flex gap-2 text-brand-gray-400 items-center'>
           <span>{data.master.username}</span>
-          <ParticipantsImages data={data.participants} />
+          {data.participantCount > 0 && (
+            <ParticipantsImages
+              data={data.participants}
+              participantCount={data.participantCount}
+            />
+          )}
           <span>장소 {data.placeCount}개</span>
           <span>{data.isPublic ? '공유됨' : '비공개'}</span>
         </div>

--- a/components/features/place-list/detail/PlaceListHeader.tsx
+++ b/components/features/place-list/detail/PlaceListHeader.tsx
@@ -47,7 +47,7 @@ export default function PlaceListHeader({ listId, hasSession }: { listId: string
             />
           )}
           <span>장소 {data.placeCount}개</span>
-          <span>{data.isPublic ? '공유됨' : '비공개'}</span>
+          <span>{data.isPublic ? '공개됨' : '비공개'}</span>
         </div>
         <p className='text-brand-gray-600'>{data.description}</p>
       </div>

--- a/components/features/place-list/detail/PlaceListPlaces.tsx
+++ b/components/features/place-list/detail/PlaceListPlaces.tsx
@@ -3,15 +3,37 @@
 import PlaceItem from './PlaceItem';
 import EmptyState from '../../../common/EmptyState';
 import { useGetPlaceListPlaces } from '@/hooks/place-list/useGetPlaceListPlaces';
+import { useSearchParams } from 'next/navigation';
+import { useMemo } from 'react';
 
 export default function PlaceListPlaces({ listId }: { listId: string }) {
   const { data } = useGetPlaceListPlaces(listId);
+  const searchParams = useSearchParams();
+  const sortBy = searchParams.get('sort') || 'updated';
+
+  const sortedPlaces = useMemo(() => {
+    return data.sort((a, b) => {
+      // 최근 수정순
+      if (sortBy === 'updated') {
+        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      }
+      // 최근 등록순
+      if (sortBy === 'createdDesc') {
+        return new Date(b.createdAt).getTime() - new Date(b.createdAt).getTime();
+      }
+      // 과거 등록순
+      if (sortBy === 'createdAsc') {
+        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+      }
+      return 0;
+    });
+  }, [data, sortBy]);
 
   if (data.length === 0) return <EmptyState message='저장된 장소가 아직 없습니다.' />;
 
   return (
     <>
-      {data.map((item) => (
+      {sortedPlaces.map((item) => (
         <PlaceItem
           key={item.id}
           place={item}

--- a/components/features/place-list/detail/PlaceListPlaces.tsx
+++ b/components/features/place-list/detail/PlaceListPlaces.tsx
@@ -3,23 +3,21 @@
 import PlaceItem from './PlaceItem';
 import EmptyState from '../../../common/EmptyState';
 import { useGetPlaceListPlaces } from '@/hooks/place-list/useGetPlaceListPlaces';
-import { useSearchParams } from 'next/navigation';
 import { useMemo } from 'react';
+import { SortType } from '@/types/placeList';
 
-export default function PlaceListPlaces({ listId }: { listId: string }) {
+export default function PlaceListPlaces({ listId, sortBy }: { listId: string; sortBy: SortType }) {
   const { data } = useGetPlaceListPlaces(listId);
-  const searchParams = useSearchParams();
-  const sortBy = searchParams.get('sort') || 'updated';
 
   const sortedPlaces = useMemo(() => {
-    return data.sort((a, b) => {
+    return [...data].sort((a, b) => {
       // 최근 수정순
       if (sortBy === 'updated') {
         return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
       }
       // 최근 등록순
       if (sortBy === 'createdDesc') {
-        return new Date(b.createdAt).getTime() - new Date(b.createdAt).getTime();
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       }
       // 과거 등록순
       if (sortBy === 'createdAsc') {

--- a/components/features/place-list/detail/PlaceListPlaces.tsx
+++ b/components/features/place-list/detail/PlaceListPlaces.tsx
@@ -7,20 +7,20 @@ import { useMemo } from 'react';
 import { SortType } from '@/types/placeList';
 
 export default function PlaceListPlaces({ listId, sortBy }: { listId: string; sortBy: SortType }) {
-  const { data } = useGetPlaceListPlaces(listId);
+  const { data } = useGetPlaceListPlaces({ listId, sortBy });
 
   const sortedPlaces = useMemo(() => {
     return [...data].sort((a, b) => {
       // 최근 수정순
-      if (sortBy === 'updated') {
-        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      }
+      // if (sortBy === 'updated') {
+      //   return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      // }
       // 최근 등록순
-      if (sortBy === 'createdDesc') {
+      if (sortBy === 'created_desc') {
         return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       }
       // 과거 등록순
-      if (sortBy === 'createdAsc') {
+      if (sortBy === 'created_asc') {
         return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
       }
       return 0;

--- a/components/features/place-list/detail/PlaceListPlaces.tsx
+++ b/components/features/place-list/detail/PlaceListPlaces.tsx
@@ -37,6 +37,7 @@ export default function PlaceListPlaces({ listId }: { listId: string }) {
         <PlaceItem
           key={item.id}
           place={item}
+          listId={listId}
         />
       ))}
     </>

--- a/components/features/place-list/detail/SortingDropdownButton.tsx
+++ b/components/features/place-list/detail/SortingDropdownButton.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import DropDown from '@/components/common/Dropdown';
+import { Icon } from '@/components/common/Icon';
+import { SortType } from '@/types/placeList';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function SortingDropdownButton() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentSortBy = searchParams.get('sort');
+  const handleSort = (sortBy: SortType) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('sort', sortBy);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
+
+  return (
+    <DropDown
+      placement='bottom'
+      offsetValue={4}
+    >
+      <DropDown.Trigger className='flex gap-1 px-3 py-1.5 rounded-[40px] bg-brand-gray-200 items-center text-brand-gray-600'>
+        {currentSortBy === 'updated' ? '최근수정' : currentSortBy === 'createdDesc' ? '최근등록' : '과거등록'}
+        <Icon
+          name='ChevronDown'
+          size={18}
+        />
+      </DropDown.Trigger>
+
+      <DropDown.Menu minWidth={false}>
+        <DropDown.Item
+          onClick={() => handleSort('updated')}
+          size='mini'
+          isSelected={currentSortBy === 'updated'}
+        >
+          최근 수정순
+        </DropDown.Item>
+        <DropDown.Item
+          onClick={() => handleSort('createdDesc')}
+          size='mini'
+          isSelected={currentSortBy === 'createdDesc'}
+        >
+          최근 등록순
+        </DropDown.Item>
+        <DropDown.Item
+          onClick={() => handleSort('createdAsc')}
+          size='mini'
+          isSelected={currentSortBy === 'createdAsc'}
+        >
+          과거 등록순
+        </DropDown.Item>
+      </DropDown.Menu>
+    </DropDown>
+  );
+}

--- a/components/features/place-list/detail/SortingDropdownButton.tsx
+++ b/components/features/place-list/detail/SortingDropdownButton.tsx
@@ -3,26 +3,21 @@
 import DropDown from '@/components/common/Dropdown';
 import { Icon } from '@/components/common/Icon';
 import { SortType } from '@/types/placeList';
-import { useRouter, useSearchParams } from 'next/navigation';
 
-export default function SortingDropdownButton() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const currentSortBy = searchParams.get('sort');
-  const handleSort = (sortBy: SortType) => {
-    const params = new URLSearchParams(searchParams);
-    params.set('sort', sortBy);
-    router.replace(`?${params.toString()}`, { scroll: false });
-  };
-
+export default function SortingDropdownButton({
+  sortBy,
+  onSortChange,
+}: {
+  sortBy: SortType;
+  onSortChange: React.Dispatch<React.SetStateAction<SortType>>;
+}) {
   return (
     <DropDown
       placement='bottom'
       offsetValue={4}
     >
       <DropDown.Trigger className='flex gap-1 px-3 py-1.5 rounded-[40px] bg-brand-gray-200 items-center text-brand-gray-600'>
-        {currentSortBy === 'updated' ? '최근수정' : currentSortBy === 'createdDesc' ? '최근등록' : '과거등록'}
+        {sortBy === 'updated' ? '최근수정' : sortBy === 'createdDesc' ? '최근등록' : '과거등록'}
         <Icon
           name='ChevronDown'
           size={18}
@@ -31,25 +26,25 @@ export default function SortingDropdownButton() {
 
       <DropDown.Menu minWidth={false}>
         <DropDown.Item
-          onClick={() => handleSort('updated')}
+          onClick={() => onSortChange('createdDesc')}
           size='mini'
-          isSelected={currentSortBy === 'updated'}
-        >
-          최근 수정순
-        </DropDown.Item>
-        <DropDown.Item
-          onClick={() => handleSort('createdDesc')}
-          size='mini'
-          isSelected={currentSortBy === 'createdDesc'}
+          isSelected={sortBy === 'createdDesc'}
         >
           최근 등록순
         </DropDown.Item>
         <DropDown.Item
-          onClick={() => handleSort('createdAsc')}
+          onClick={() => onSortChange('createdAsc')}
           size='mini'
-          isSelected={currentSortBy === 'createdAsc'}
+          isSelected={sortBy === 'createdAsc'}
         >
           과거 등록순
+        </DropDown.Item>
+        <DropDown.Item
+          onClick={() => onSortChange('updated')}
+          size='mini'
+          isSelected={sortBy === 'updated'}
+        >
+          최근 수정순
         </DropDown.Item>
       </DropDown.Menu>
     </DropDown>

--- a/components/features/place-list/detail/SortingDropdownButton.tsx
+++ b/components/features/place-list/detail/SortingDropdownButton.tsx
@@ -17,7 +17,7 @@ export default function SortingDropdownButton({
       offsetValue={4}
     >
       <DropDown.Trigger className='flex gap-1 px-3 py-1.5 rounded-[40px] bg-brand-gray-200 items-center text-brand-gray-600'>
-        {sortBy === 'updated' ? '최근수정' : sortBy === 'createdDesc' ? '최근등록' : '과거등록'}
+        {sortBy === 'created_desc' ? '최근등록' : '과거등록'}
         <Icon
           name='ChevronDown'
           size={18}
@@ -26,26 +26,26 @@ export default function SortingDropdownButton({
 
       <DropDown.Menu minWidth={false}>
         <DropDown.Item
-          onClick={() => onSortChange('createdDesc')}
+          onClick={() => onSortChange('created_desc')}
           size='mini'
-          isSelected={sortBy === 'createdDesc'}
+          isSelected={sortBy === 'created_desc'}
         >
           최근 등록순
         </DropDown.Item>
         <DropDown.Item
-          onClick={() => onSortChange('createdAsc')}
+          onClick={() => onSortChange('created_asc')}
           size='mini'
-          isSelected={sortBy === 'createdAsc'}
+          isSelected={sortBy === 'created_asc'}
         >
           과거 등록순
         </DropDown.Item>
-        <DropDown.Item
+        {/* <DropDown.Item
           onClick={() => onSortChange('updated')}
           size='mini'
           isSelected={sortBy === 'updated'}
         >
           최근 수정순
-        </DropDown.Item>
+        </DropDown.Item> */}
       </DropDown.Menu>
     </DropDown>
   );

--- a/components/features/place-list/tag/TagList.tsx
+++ b/components/features/place-list/tag/TagList.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { Icon } from '@/components/common/Icon';
 import TagListItem from './TagListItem';
 import { useState } from 'react';
 import { useDragScroll } from '@/hooks/useDragScroll';
 import { useGetPlaceListTags } from '@/hooks/place-list/useGetPlaceListTags';
+import SortingDropdownButton from '../detail/SortingDropdownButton';
 
 // 장소 리스트에 포함된 태그를 보여주는 태그 리스트 컴포넌트(상단에 위치)
 export default function TagList({ listId }: { listId: string }) {
@@ -18,13 +18,10 @@ export default function TagList({ listId }: { listId: string }) {
 
   return (
     <div className='flex gap-2 text-typo-description items-center'>
-      <button className='flex gap-1 px-3 py-1.5 rounded-[40px] bg-brand-gray-200 items-center text-brand-gray-600'>
-        최근 수정
-        <Icon
-          name='ChevronDown'
-          size={18}
-        />
-      </button>
+      {/* 장소 정렬 버튼 */}
+      <SortingDropdownButton />
+
+      {/* 태그 리스트 */}
       <div
         ref={ref}
         {...dragHandler}

--- a/components/features/place-list/tag/TagList.tsx
+++ b/components/features/place-list/tag/TagList.tsx
@@ -4,7 +4,6 @@ import TagListItem from './TagListItem';
 import { useState } from 'react';
 import { useDragScroll } from '@/hooks/useDragScroll';
 import { useGetPlaceListTags } from '@/hooks/place-list/useGetPlaceListTags';
-import SortingDropdownButton from '../detail/SortingDropdownButton';
 
 // 장소 리스트에 포함된 태그를 보여주는 태그 리스트 컴포넌트(상단에 위치)
 export default function TagList({ listId }: { listId: string }) {
@@ -17,26 +16,20 @@ export default function TagList({ listId }: { listId: string }) {
   };
 
   return (
-    <div className='flex gap-2 text-typo-description items-center'>
-      {/* 장소 정렬 버튼 */}
-      <SortingDropdownButton />
-
-      {/* 태그 리스트 */}
-      <div
-        ref={ref}
-        {...dragHandler}
-        className='flex gap-2 overflow-x-scroll flex-1 items-center no-scrollbar'
-      >
-        {data.map((item) => (
-          <TagListItem
-            key={item.id}
-            tag={item}
-            isActivated={activeIds.includes(item.id)}
-            onClick={() => handleToggleTag(item.id)}
-          />
-        ))}
-        <button className='px-3 py-1.75 text-brand-blue-700 shrink-0'>태그 수정</button>
-      </div>
+    <div
+      ref={ref}
+      {...dragHandler}
+      className='flex gap-2 overflow-x-scroll flex-1 items-center no-scrollbar'
+    >
+      {data.map((item) => (
+        <TagListItem
+          key={item.id}
+          tag={item}
+          isActivated={activeIds.includes(item.id)}
+          onClick={() => handleToggleTag(item.id)}
+        />
+      ))}
+      <button className='px-3 py-1.75 text-brand-blue-700 shrink-0'>태그 수정</button>
     </div>
   );
 }

--- a/components/features/plan/PlaceList/PlanPlaceListDetail.tsx
+++ b/components/features/plan/PlaceList/PlanPlaceListDetail.tsx
@@ -10,7 +10,7 @@ interface PlanPlaceListDetailProps {
 }
 
 export default function PlanPlaceListDetail({ listId, title, planId, onBack }: PlanPlaceListDetailProps) {
-  const { data: places } = useGetPlaceListPlaces(listId);
+  const { data: places } = useGetPlaceListPlaces({ listId, sortBy: 'created_desc' });
 
   return (
     <div className='flex flex-col gap-3'>

--- a/components/features/plan/PlaceList/PlanPlaceListItem.tsx
+++ b/components/features/plan/PlaceList/PlanPlaceListItem.tsx
@@ -13,7 +13,7 @@ export function PlanPlaceListItem({ place, onClick }: { place: PlaceListOverview
           <span className='text-typo-sub-title max-w-58 xl:max-w-75 truncate'>{place.title}</span>
         </div>
         <div className='flex gap-2 text-typo-description font-light text-brand-gray-400'>
-          <span>{place.isPublic ? '공유 목록' : '비공개'}</span>
+          <span>{place.isPublic ? '공개됨' : '비공개'}</span>
           <span>장소 {place.placeCount}개</span>
         </div>
       </div>

--- a/hooks/place-list/useConfirmDeletePlace.ts
+++ b/hooks/place-list/useConfirmDeletePlace.ts
@@ -1,0 +1,24 @@
+import { useModalStore } from '@/lib/store/modalStore';
+import { useDeletePlace } from './useDeletePlace';
+
+export const useConfirmDeletePlace = (listId: string) => {
+  const { mutateAsync: deletePlace } = useDeletePlace(listId);
+  const { open } = useModalStore();
+
+  const confirmDeletePlaceList = async (placeName: string, placeId: string) => {
+    open({
+      type: 'confirmAction',
+      props: {
+        description: `'${placeName}'을 삭제하시겠어요?`,
+        confirmButtonText: '삭제하기',
+        onConfirm: async () => {
+          await deletePlace(placeId);
+          // TODO: 성공 토스트 알림 등 추가
+          // toast.success(`${placeName}가 삭제되었습니다.`)
+        },
+      },
+    });
+  };
+
+  return { confirmDeletePlaceList };
+};

--- a/hooks/place-list/useDeletePlace.ts
+++ b/hooks/place-list/useDeletePlace.ts
@@ -1,0 +1,43 @@
+import { deletePlace } from '@/lib/actions/placeList';
+import { useModalStore } from '@/lib/store/modalStore';
+import { getErrorMessage, RpcError, RpcErrorMessage } from '@/types/errors';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useDeletePlace = (listId: string) => {
+  const queryClient = useQueryClient();
+  // TODO: 나중에 에러 모달을 토스트 메세지로 교체
+  const { open } = useModalStore();
+
+  return useMutation({
+    mutationFn: async (placeId: string) => {
+      const result = await deletePlace({ listId, placeId });
+
+      if (!result.success) {
+        throw new RpcError(result.error.message, result.error.code);
+      }
+
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['place-list', listId, 'places'],
+      });
+    },
+    onError: (error) => {
+      console.error('❌ 단일 장소 삭제 실패');
+
+      const message =
+        error instanceof RpcError
+          ? getErrorMessage(error.message as RpcErrorMessage, { subject: '단일 장소', action: '삭제' })
+          : getErrorMessage('INTERNAL_ERROR', { subject: '단일 장소', action: '삭제' });
+
+      open({
+        type: 'error',
+        props: {
+          title: '단일 장소 삭제 실패',
+          description: `${message}\n잠시 후 다시 시도해주세요.`,
+        },
+      });
+    },
+  });
+};

--- a/hooks/place-list/useGetMyRole.ts
+++ b/hooks/place-list/useGetMyRole.ts
@@ -1,0 +1,11 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { placeListDetailQueryOptions } from './useGetPlaceListDetail';
+import { PlaceListDetail } from '@/types/placeList';
+
+// 장소 리스트 myRole 가져오기
+export const useGetMyRole = (id: string) => {
+  return useSuspenseQuery({
+    ...placeListDetailQueryOptions(id),
+    select: (data: PlaceListDetail) => data.myRole,
+  });
+};

--- a/hooks/place-list/useGetPlaceListPlaces.ts
+++ b/hooks/place-list/useGetPlaceListPlaces.ts
@@ -1,8 +1,9 @@
-import { PageParam, Place } from '@/types/placeList';
+import { GetPlacesParams, PageParam, Place, SortType } from '@/types/placeList';
 import { infiniteQueryOptions, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
-const fetchPlaceListPlaces = async (listId: string, cursor: PageParam): Promise<Place[]> => {
+const fetchPlaceListPlaces = async (listId: string, cursor: PageParam, sortBy: SortType): Promise<Place[]> => {
   const params = new URLSearchParams();
+  params.set('sortBy', sortBy);
   if (cursor) {
     params.set('createdAt', cursor.createdAt);
     params.set('id', cursor.id);
@@ -13,17 +14,17 @@ const fetchPlaceListPlaces = async (listId: string, cursor: PageParam): Promise<
 };
 
 // 리스트에 저장된 장소 queryOptions
-export const placeListPlacesQueryOptions = (listId: string) => {
+export const placeListPlacesQueryOptions = ({ listId, sortBy }: GetPlacesParams) => {
   return infiniteQueryOptions({
-    queryKey: ['place-list', listId, 'places'],
-    queryFn: ({ pageParam }) => fetchPlaceListPlaces(listId, pageParam),
+    queryKey: ['place-list', listId, 'places', sortBy],
+    queryFn: ({ pageParam }) => fetchPlaceListPlaces(listId, pageParam, sortBy),
     initialPageParam: null as PageParam,
     getNextPageParam: (lastPage) =>
       lastPage.length < 20 ? undefined : { createdAt: lastPage.at(-1)!.createdAt, id: lastPage.at(-1)!.id },
   });
 };
 
-export const useGetPlaceListPlaces = (listId: string) => {
-  const { data, ...rest } = useSuspenseInfiniteQuery(placeListPlacesQueryOptions(listId));
+export const useGetPlaceListPlaces = ({ listId, sortBy }: GetPlacesParams) => {
+  const { data, ...rest } = useSuspenseInfiniteQuery(placeListPlacesQueryOptions({ listId, sortBy }));
   return { data: data.pages.flat(), ...rest };
 };

--- a/hooks/place-list/useUpdatePlace.ts
+++ b/hooks/place-list/useUpdatePlace.ts
@@ -1,0 +1,50 @@
+import { updatePlace } from '@/lib/actions/placeList';
+import { useModalStore } from '@/lib/store/modalStore';
+import { getErrorMessage, RpcError, RpcErrorMessage } from '@/types/errors';
+import { Place } from '@/types/placeList';
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useUpdatePlace = (listId: string) => {
+  const queryClient = useQueryClient();
+  // TODO: 나중에 에러 모달을 토스트 메세지로 교체
+  const { open } = useModalStore();
+
+  return useMutation({
+    mutationFn: async ({ placeId, memo }: { placeId: string; memo: string | null }) => {
+      const result = await updatePlace({ listId, placeId, memo });
+
+      if (!result.success) {
+        throw new RpcError(result.error.message, result.error.code);
+      }
+
+      return result;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.setQueryData(['place-list', listId, 'places'], (old: InfiniteData<Place[]> | undefined) => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) =>
+            page.map((p) => (p.id === variables.placeId ? { ...p, memoContent: variables.memo } : p)),
+          ),
+        };
+      });
+    },
+    onError: (error) => {
+      console.error('❌ 단일 장소 편집 실패');
+
+      const message =
+        error instanceof RpcError
+          ? getErrorMessage(error.message as RpcErrorMessage, { subject: '단일 장소', action: '편집' })
+          : getErrorMessage('INTERNAL_ERROR', { subject: '단일 장소', action: '편집' });
+
+      open({
+        type: 'error',
+        props: {
+          title: '단일 장소 편집 실패',
+          description: `${message}\n잠시 후 다시 시도해주세요.`,
+        },
+      });
+    },
+  });
+};

--- a/hooks/place-list/useUpdatePlace.ts
+++ b/hooks/place-list/useUpdatePlace.ts
@@ -20,15 +20,18 @@ export const useUpdatePlace = (listId: string) => {
       return result;
     },
     onSuccess: (_, variables) => {
-      queryClient.setQueryData(['place-list', listId, 'places'], (old: InfiniteData<Place[]> | undefined) => {
-        if (!old) return old;
-        return {
-          ...old,
-          pages: old.pages.map((page) =>
-            page.map((p) => (p.id === variables.placeId ? { ...p, memoContent: variables.memo } : p)),
-          ),
-        };
-      });
+      queryClient.setQueriesData(
+        { queryKey: ['place-list', listId, 'places'] },
+        (old: InfiniteData<Place[]> | undefined) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page) =>
+              page.map((p) => (p.id === variables.placeId ? { ...p, memoContent: variables.memo } : p)),
+            ),
+          };
+        },
+      );
     },
     onError: (error) => {
       console.error('❌ 단일 장소 편집 실패');

--- a/lib/actions/api/placeList.ts
+++ b/lib/actions/api/placeList.ts
@@ -1,28 +1,42 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { toCamelKey } from '@/lib/utils/toCamelCase';
-import type { Place, PageParam, AllPlaceLists, ListType, PlaceListDetail, Tag } from '@/types/placeList';
+import type {
+  Place,
+  PageParam,
+  AllPlaceLists,
+  ListType,
+  PlaceListDetail,
+  Tag,
+  GetPlacesParams,
+} from '@/types/placeList';
 import { RpcError, RpcErrorMessage } from '@/types/errors';
 
-interface GetPlaceListPlacesProps {
+interface GetPlaceListPlacesProps extends GetPlacesParams {
   supabase: SupabaseClient;
-  listId: string;
   cursor?: PageParam;
 }
 
+// 저장된 장소 조회
 export const getPlaceListPlaces = async ({
   supabase,
   listId,
+  sortBy = 'created_desc',
   cursor = null,
 }: GetPlaceListPlacesProps): Promise<Place[]> => {
   const { data, error } = await supabase.rpc('get_place_list_places', {
     p_list_id: listId,
+    p_sort_by: sortBy,
     p_cursor_created_at: cursor?.createdAt ?? null,
     p_cursor_id: cursor?.id ?? null,
     p_limit: 20,
   });
 
-  if (error) throw error;
-  if (!data) throw new Error('저장된 장소를 가져오는 데 실패했습니다.');
+  if (error) throw new RpcError(error.message as RpcErrorMessage, error.code);
+
+  if (!data) {
+    console.error('❌ 저장된 장소 조회 실패: ', error);
+    throw new RpcError('NOT_FOUND');
+  }
   return toCamelKey<Place[]>(data);
 };
 

--- a/lib/actions/api/prefetch/prefetchPlaceListDetail.ts
+++ b/lib/actions/api/prefetch/prefetchPlaceListDetail.ts
@@ -8,14 +8,16 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 export async function prefetchPlaceListDetail(queryClient: QueryClient, listId: string, supabase: SupabaseClient) {
   await Promise.all([
     queryClient.prefetchInfiniteQuery({
-      ...placeListPlacesQueryOptions(listId),
+      ...placeListPlacesQueryOptions({ listId, sortBy: 'created_desc' }),
       // queryFn만 서버 직접 호출로 오버라이드
-      queryFn: ({ pageParam }) => getPlaceListPlaces({ supabase, listId, cursor: pageParam as PageParam }),
+      queryFn: ({ pageParam }) =>
+        getPlaceListPlaces({ supabase, listId, sortBy: 'created_desc', cursor: pageParam as PageParam }),
       initialPageParam: null as PageParam,
     }),
-    queryClient.prefetchQuery({
-      ...placeListTagsQueryOptions(listId),
-      queryFn: () => getPlaceListTags({ supabase, listId }),
-    }),
+    // TODO: 2차에 태그 기능 추가
+    // queryClient.prefetchQuery({
+    //   ...placeListTagsQueryOptions(listId),
+    //   queryFn: () => getPlaceListTags({ supabase, listId }),
+    // }),
   ]);
 }

--- a/lib/actions/placeList.ts
+++ b/lib/actions/placeList.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { UpdatePlaceParams } from '@/types/placeList';
 import { auth } from '../utils/auth';
 import { supabaseAdmin, supabaseUser } from '../utils/supabase';
 import { ActionResult, isPostgresError, RpcErrorMessage, SQLSTATE_TO_RPC_ERROR } from '@/types/errors';
@@ -69,7 +70,7 @@ export const deletePlace = async ({
   try {
     const supabase = await supabaseUser();
     const { error } = await supabase.rpc('delete_place', {
-      p_place_list_id: listId,
+      p_list_id: listId,
       p_place_id: placeId,
     });
 
@@ -82,6 +83,31 @@ export const deletePlace = async ({
     return { success: true, data: null };
   } catch (error: unknown) {
     console.error('❌ 단일 장소 삭제 실패: ', error);
+    const code = isPostgresError(error) ? error.code : undefined;
+    const message = ((code && SQLSTATE_TO_RPC_ERROR[code]) ?? 'INTERNAL_ERROR') as RpcErrorMessage;
+    return { success: false, error: { message, code } };
+  }
+};
+
+// 단일 장소 편집
+export const updatePlace = async ({ listId, placeId, memo }: UpdatePlaceParams): Promise<ActionResult<null>> => {
+  try {
+    const supabase = await supabaseUser();
+    const { error } = await supabase.rpc('update_place', {
+      p_list_id: listId,
+      p_place_id: placeId,
+      p_memo: memo,
+    });
+
+    if (error) {
+      console.error('❌ 단일 장소 편집 실패: ', error);
+      const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
+      return { success: false, error: { message, code: error.code } };
+    }
+
+    return { success: true, data: null };
+  } catch (error: unknown) {
+    console.error('❌ 단일 장소 편집 실패: ', error);
     const code = isPostgresError(error) ? error.code : undefined;
     const message = ((code && SQLSTATE_TO_RPC_ERROR[code]) ?? 'INTERNAL_ERROR') as RpcErrorMessage;
     return { success: false, error: { message, code } };

--- a/lib/actions/placeList.ts
+++ b/lib/actions/placeList.ts
@@ -57,3 +57,33 @@ export const deletePlaceList = async (listId: string): Promise<ActionResult<null
     return { success: false, error: { message, code } };
   }
 };
+
+// 장소 리스트에 저장된 단일 장소 삭제
+export const deletePlace = async ({
+  listId,
+  placeId,
+}: {
+  listId: string;
+  placeId: string;
+}): Promise<ActionResult<null>> => {
+  try {
+    const supabase = await supabaseUser();
+    const { error } = await supabase.rpc('delete_place', {
+      p_place_list_id: listId,
+      p_place_id: placeId,
+    });
+
+    if (error) {
+      console.error('❌ 단일 장소 삭제 실패: ', error);
+      const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
+      return { success: false, error: { message, code: error.code } };
+    }
+
+    return { success: true, data: null };
+  } catch (error: unknown) {
+    console.error('❌ 단일 장소 삭제 실패: ', error);
+    const code = isPostgresError(error) ? error.code : undefined;
+    const message = ((code && SQLSTATE_TO_RPC_ERROR[code]) ?? 'INTERNAL_ERROR') as RpcErrorMessage;
+    return { success: false, error: { message, code } };
+  }
+};

--- a/types/placeList.ts
+++ b/types/placeList.ts
@@ -5,6 +5,9 @@ import { Role } from './shareOption';
 export type ListType = 'all' | 'owned' | 'shared';
 export type TagColor = 'red' | 'hotpink' | 'yellow' | 'green' | 'blue' | 'purple' | 'grey';
 
+// 저장된 장소 정렬 타입 - 최근 등록순, 과거 등록순, 최근 수정순
+export type SortType = 'createdAsc' | 'createdDesc' | 'updated';
+
 // 커서 기반 무한스크롤
 export type PageParam = {
   id: string;
@@ -51,7 +54,7 @@ export interface PlaceListDetail extends PlaceListOverview {
 export interface PlaceListMember {
   id: number;
   username: string;
-  profileImage: string | null;
+  profileImageUrl: string | null;
 }
 
 // 단일 장소 아이템

--- a/types/placeList.ts
+++ b/types/placeList.ts
@@ -60,7 +60,6 @@ export interface PlaceListMember {
 // 단일 장소 아이템
 export interface Place {
   id: string;
-  placeListId: string;
   corePlaceId: string;
   latitude: number | null;
   longitude: number | null;

--- a/types/placeList.ts
+++ b/types/placeList.ts
@@ -71,3 +71,11 @@ export interface Place {
   createdAt: string;
   updatedAt: string;
 }
+
+// 단일 장소 편집 파라미터
+export interface UpdatePlaceParams {
+  listId: string;
+  placeId: string;
+  memo: string | null;
+  //  tags: Tag[]
+}

--- a/types/placeList.ts
+++ b/types/placeList.ts
@@ -6,7 +6,7 @@ export type ListType = 'all' | 'owned' | 'shared';
 export type TagColor = 'red' | 'hotpink' | 'yellow' | 'green' | 'blue' | 'purple' | 'grey';
 
 // 저장된 장소 정렬 타입 - 최근 등록순, 과거 등록순, 최근 수정순
-export type SortType = 'createdAsc' | 'createdDesc' | 'updated';
+export type SortType = 'created_desc' | 'created_asc';
 
 // 커서 기반 무한스크롤
 export type PageParam = {
@@ -78,4 +78,10 @@ export interface UpdatePlaceParams {
   placeId: string;
   memo: string | null;
   //  tags: Tag[]
+}
+
+// 저장된 장소 호출 파라미터
+export interface GetPlacesParams {
+  listId: string;
+  sortBy: SortType;
 }

--- a/types/placeList.ts
+++ b/types/placeList.ts
@@ -50,8 +50,8 @@ export interface PlaceListDetail extends PlaceListOverview {
 // 장소 리스트 멤버
 export interface PlaceListMember {
   id: number;
-  username?: string | null;
-  profileImage?: string | null;
+  username: string;
+  profileImage: string | null;
 }
 
 // 단일 장소 아이템


### PR DESCRIPTION
## 🛠️ 과제 요약

- 지도를 제외한 장소 리스트 미구현 기능 적용
- 공용 드롭다운 메뉴 관련 컴포넌트에 새로운 prop 추가

## 📝 요구 사항과 구현 내용

#### 1️⃣ 장소 리스트 상세페이지 미구현 부분 적용
<img width="200" alt="image" src="https://github.com/user-attachments/assets/6cb1b191-bb33-4df3-a94d-8a5890b9bea3" /><br/>
- `ParticipantsImages.tsx`: 참여 유저 프로필 이미지 표시(3인 이상은 +1과 같이 숫자로 표시)
- 공개/비공개 여부 표시
- 화살표 모양 공유 버튼 - 보기용 링크 모달 연결
- 정렬 버튼 적용 - 최근 등록순 / 과거 등록순

#### 2️⃣ 정렬 버튼 적용으로 인한 컴포넌트 구조, RPC 함수(get_place_list_places), 클라이언트 함수 수정
- 무한 스크롤 방식으로 구현되어 있는 장소를 정렬할 경우 데이터 정합성이 보장되도록 RPC 함수, 관련 클라이언트 함수들이 sortBy 값을 받도록 수정
- `PlaceListContent.tsx`: 정렬 드롭다운 메뉴 컴포넌트(`SortingDropdownButton.tsx`)와 장소 목록 컴포넌트가 같은 정렬 상태를 공유해야 했기 때문에 생성한 컴포넌트
- 논의한 대로 최근 수정순은 주석처리(추후 완전 삭제 가능)

#### 3️⃣ 단일 장소 편집 및 삭제 적용
<img width="200" alt="스크린샷 2026-07-24 오후 11 39 15" src="https://github.com/user-attachments/assets/d53ac383-e674-4ab9-9815-4a08c5be6d8a" /><br/>
- memo만 받아서 수정(태그 관련 기능을 전부 2차 MVP로 미루기로 결정했기에 현재는 메모 수정만 적용한 상태)
- X 버튼에 장소 삭제 기능 연결 - 버튼 클릭 시 확인 모달이 뜹니다!
- 단일 장소 편집 버튼을 viewer는 볼 수 없도록 AuthorityWrapper로 감싸서 처리했습니다! 

#### 4️⃣ 공용 드롭다운 메뉴 스타일 수정
- 공용 드롭다운을 좀 더 자유롭게 사용할 수 있게 스타일을 수정
- `Item.tsx`: 선택된 상태를 표시하기 위한 isSelected, 미니사이즈 사용을 위한 size prop 추가
- `Menu.tsx`: minWidth가 필요한 곳에서만 쓰이도록 prop으로 추가
- `Trigger.tsx`: trigger에 다양한 디자인 적용이 가능하도록 className prop 추가
- `index.tsx`: trigger와 버튼 사이 간격 조정이 가능하도록 offset prop 추가
> 정렬 드롭다운 메뉴 사이즈가 다른 곳에서 사용하는 것보다 작아서 스타일 수정이 필요했습니다..!

## 🧪 테스트 방법
- 'editor' 테스트는 저번에 초대로 들어오셨던 
<img width="200" alt="스크린샷 2026-07-24 오후 11 57 35" src="https://github.com/user-attachments/assets/9baa08e8-a217-436f-b5af-d5abe55bb27d" /><br/>
요걸로 하시면 쉬울 거예요! 리스트 삭제만 불가하게 처리해뒀습니답
- 'viewer' 테스트는 드롭다운 메뉴가 안 보이는지, 장소 편집 버튼이 안 보이는지만 확인해주시면 될 것 같습니다!

## 🔗 연관된 이슈
- close #52
- close #53
