### PR TITLE
[Bug] 구글 로그인이 가능한 이메일 계정이 구글 로그인 연동이 안되는 이슈

### DIFF
--- a/lib/utils/auth.ts
+++ b/lib/utils/auth.ts
@@ -1,9 +1,10 @@
-import NextAuth from 'next-auth';
 import { SupabaseAdapter } from '@auth/supabase-adapter';
-import Google from 'next-auth/providers/google';
-import Credentials from 'next-auth/providers/credentials';
-import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+import Google from 'next-auth/providers/google';
+
 import { supabaseAdmin } from '@/lib/utils/supabase';
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
@@ -12,6 +13,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     Google({
       clientId: process.env.AUTH_GOOGLE_ID,
       clientSecret: process.env.AUTH_GOOGLE_SECRET,
+      allowDangerousEmailAccountLinking: true,
+      authorization: {
+        params: {
+          prompt: 'select_account',
+        },
+      },
     }),
     Credentials({
       credentials: {
@@ -101,29 +108,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         return true;
       }
 
-      // 기존 유저가 구글 로그인 시도 BUT accounts 테이블에 연결 정보가 없는 경우
-      // ex: 이메일로 가입했다가 동일한 이메일로 구글 로그인 시도
-      if (existingProfile && account?.provider === 'google') {
-        const { data: existingAccount } = await supabaseAdmin
-          .schema('next_auth')
-          .from('accounts')
-          .select('id')
-          .eq('userId', existingProfile.id)
-          .eq('provider', 'google')
-          .maybeSingle();
-
-        if (!existingAccount) {
-          // 서버에서 계정 연결 진행
-          await supabaseAdmin.schema('next_auth').from('next_auth.accounts').insert({
-            userId: existingProfile.id,
-            provider: account?.provider,
-            providerAccountId: account?.providerAccountId,
-            type: account?.type,
-          });
-          return true;
-        }
-      }
-
       // 그 외 모든 성공케이스(기존 유저, 이메일 가입 직후 등)은 로비로 이동
       return true;
     },
@@ -131,7 +115,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       // 최초 로그인 또는 update() 함수 호출 시에만 DB조회
       if (user || trigger === 'update') {
         const userId = user?.id || token.id;
-        const { data, error } = await supabaseAdmin
+        const { data } = await supabaseAdmin
           .from('profiles')
           .select('role, username, profile_image_url')
           .eq('id', userId)


### PR DESCRIPTION
##  🐛 버그 작성
- 구글 로그인이 가능한 이메일계정이 구글 로그인을 시도할 경우 OauthAccountNotLinked로 리다이렉트 되는 현상
- 크롬에 로그인 되어있는 구글 계정 세션이 있을 경우 이를 기준으로 구글 로그인을 시도하는 현상(계정 선택X)

## 원인 
- 구글 로그인이 가능한 이메일계정이 구글 로그인을 시도할 경우 해당 계정을 accounts에 insert하는 로직을 만들었으나 auth.js가 계정 연결이 없는 것을 확인하고 signIn콜백을 호출하기 전에 이미 OauthAccountNotLinked로 리다이렉트를 실행하는 현상
- insert 호출에도 오류가 있어서 제대로 작동했어도 insert되지 않았을 것.. 

## 해결 방법
- 기존 연동 코드 제거
- Google provider에 allowDangerousEmailAccountLinking: true 추가 -> 에러대신 linkAccount가 호출되어 next_auth.accounts에 계정 생성
- 크롬에 로그인된 계정과 무관하게 항상 계정 선택화면을 보여주는 옵션 추가
```
      allowDangerousEmailAccountLinking: true,
      authorization: {
        params: {
          prompt: 'select_account',
        },
      },
```

close #107 