### PR TITLE
[PE-003]이동 메모 모달

### DIFF
--- a/components/features/plan/plan-detail/PlanRouteMemoModal.tsx
+++ b/components/features/plan/plan-detail/PlanRouteMemoModal.tsx
@@ -1,0 +1,246 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { Icon } from '@/components/common/Icon';
+import { scheduleItemsQueryOptions } from '@/hooks/plan/useGetScheduleItems';
+import { useUpdateRouteMemoForm } from '@/hooks/plan/useUpdateRouteMemoForm';
+import { checkIsKorean } from '@/hooks/useNewPlaceForm';
+import { buildGoogleMapsDirectionsUrl } from '@/lib/utils/getGoogleMapsDirectionUrl';
+import { getRouteDistance } from '@/lib/utils/googleRoutes';
+import { formatDuration } from '@/lib/utils/minutes';
+import { TRANSFORT_EMOJI } from '@/lib/utils/transport';
+import { PlanTransitMode, TRANSIT_MODE_LABELS, type PlanItem } from '@/types/plan';
+
+import ModalHeader from '../../place/save/modal-item/ModalHeader';
+
+interface PlanRouteMemoModalProps {
+  planId: string;
+  item: PlanItem;
+  onClose: () => void;
+}
+
+const TRANSIT_MODES = Object.keys(TRANSIT_MODE_LABELS) as PlanTransitMode[];
+
+export default function PlanRouteMemoModal({ planId, item, onClose }: PlanRouteMemoModalProps) {
+  const queryClient = useQueryClient();
+  const items = queryClient.getQueryData<PlanItem[]>(scheduleItemsQueryOptions(planId, item.scheduleId).queryKey) ?? [];
+
+  const currentIndex = items.findIndex((i) => i.id === item.id);
+  const currentItem = items[currentIndex];
+  // memo 아이템은 좌표가 없으니 건너뛰고, 다음 place 타입 아이템을 도착지로 삼음
+  const nextItem = items.slice(currentIndex + 1).find((i) => i.type === 'place');
+
+  const { state, dispatch, handleSubmit, isPending, error } = useUpdateRouteMemoForm(planId, item.scheduleId, item.id, {
+    transitMode: currentItem?.transitMode ?? 'transit',
+    transitDistance: currentItem?.transitDistance ?? null,
+    transitTime: currentItem?.transitTime ?? null,
+    transitMemo: currentItem?.transitMemo ?? null,
+  });
+
+  const [isCalculating, setIsCalculating] = useState(false);
+
+  const isKorea = item.latitude != null && item.longitude != null && checkIsKorean(item.latitude, item.longitude);
+
+  const handleChangeTransitMode = async (mode: PlanTransitMode) => {
+    dispatch({ type: 'SET_TRANSIT_MODE', value: mode });
+
+    if (
+      !currentItem ||
+      !nextItem ||
+      currentItem.latitude == null ||
+      currentItem.longitude == null ||
+      nextItem.latitude == null ||
+      nextItem.longitude == null
+    ) {
+      return;
+    }
+
+    setIsCalculating(true);
+    try {
+      const route = await getRouteDistance(
+        { lat: currentItem.latitude, lng: currentItem.longitude, googlePlaceId: currentItem.googlePlaceId },
+        { lat: nextItem.latitude, lng: nextItem.longitude, googlePlaceId: nextItem.googlePlaceId },
+        mode,
+      );
+
+      dispatch({ type: 'SET_TRANSIT_DISTANCE', value: route ? route.distanceMeters / 1000 : null });
+      dispatch({ type: 'SET_TRANSIT_TIME', value: route ? route.durationMinutes : null });
+    } finally {
+      setIsCalculating(false);
+    }
+  };
+
+  if (!currentItem) return null; // 캐시에 없는 예외 상황 방어
+
+  const emoji = TRANSFORT_EMOJI[state.transitMode] ?? '📍';
+
+  const handleGoogleRouteURL = () => {
+    if (
+      !nextItem ||
+      currentItem.latitude == null ||
+      currentItem.longitude == null ||
+      nextItem.latitude == null ||
+      nextItem.longitude == null
+    )
+      return;
+    const url = buildGoogleMapsDirectionsUrl(
+      {
+        lat: currentItem.latitude,
+        lng: currentItem.longitude,
+        googlePlaceId: currentItem.googlePlaceId,
+        name: currentItem.placeName,
+      },
+      {
+        lat: nextItem.latitude,
+        lng: nextItem.longitude,
+        googlePlaceId: nextItem.googlePlaceId,
+        name: nextItem.placeName,
+      },
+      state.transitMode,
+    );
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  return createPortal(
+    <>
+      <div
+        className='modal-overlay'
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+      >
+        <div
+          className='relative flex flex-col bg-white rounded-lg relative pt-7 px-6 pb-6 min-h-125 max-w-90'
+          onClick={(e) => e.stopPropagation()}
+        >
+          <ModalHeader
+            title='이동 정보 관리'
+            onClose={onClose}
+          />
+
+          {/* content */}
+          <div className='flex flex-col gap-4 max-h-100 overflow-y-auto mt-4'>
+            <div className='flex flex-col gap-2'>
+              <p className='text-typo-description text-brand-gray-700'>예상 이동 시간</p>
+              <div className='flex justify-between items-center bg-brand-blue-50 px-3 py-2 rounded-lg text-brand-gray-600'>
+                <div className='flex flex-row gap-2 '>
+                  <span className='font-mona12 text-emoji-sm pl-0.5 pb-0.5'>{emoji}</span>
+                  <span>{TRANSIT_MODE_LABELS[state.transitMode]}</span>
+                </div>
+                <span>
+                  {isCalculating
+                    ? '계산 중...'
+                    : state.transitTime != null
+                      ? formatDuration(state.transitTime)
+                      : '경로 없음'}
+                </span>
+              </div>
+              {nextItem && (
+                <button
+                  className='flex flex-row justify-center gap-1.5 items-center text-typo-description text-medium text-brand-gray-600 py-3 border rounded-sm border-brand-gray-200 hover:bg-gray-100 cursor-pointer'
+                  onClick={handleGoogleRouteURL}
+                >
+                  <Icon
+                    name='Google'
+                    size={15}
+                    className='text-brand-gray-500 cursor-pointer'
+                  />
+                  구글에서 이동경로 확인하기
+                </button>
+              )}
+            </div>
+
+            {/* 이동수단 변경 */}
+            <div className='flex flex-col gap-2'>
+              <p className='text-typo-description text-brand-gray-700'>이동수단 변경</p>
+              <div>
+                <div className='flex gap-2 flex-wrap w-full py-2 bg-brand-gray-50 mb-2 justify-center'>
+                  {TRANSIT_MODES.map((mode) => {
+                    const isDisabled = isKorea && mode !== 'transit';
+                    return (
+                      <button
+                        key={mode}
+                        type='button'
+                        onClick={() => handleChangeTransitMode(mode)}
+                        disabled={isCalculating || isDisabled}
+                        className={`flex items-center justify-center px-3 py-1.5 rounded-sm border text-typo-description whitespace-nowrap ${
+                          state.transitMode === mode
+                            ? 'bg-brand-blue-50 border-brand-blue-200 text-brand-blue-500'
+                            : isDisabled
+                              ? 'bg-brand-gray-200 border-brand-gray-200 text-brand-gray-500 cursor-not-allowed'
+                              : 'bg-white border-brand-gray-300 text-brand-gray-500'
+                        }`}
+                      >
+                        {state.transitMode === mode && (
+                          <Icon
+                            name='Check'
+                            size={18}
+                            className='mr-1 text-brand-blue-500 shrink-0'
+                          />
+                        )}
+                        {TRANSIT_MODE_LABELS[mode]}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className='text-typo-caption text-brand-gray-600 textwrap'>
+                  *한국에서는 대중교통 경로만 제공되며, 출발지와 목적지에 따라 경로가 제공되지 않을 수 있습니다.
+                </p>
+              </div>
+            </div>
+            {/* 구분선 */}
+            <hr className='border-brand-gray-200' />
+
+            {/* 이동 메모 */}
+            <div className='flex flex-col gap-2'>
+              <p className='text-typo-description text-brand-gray-700'>이동 메모</p>
+              <div className='bg-brand-gray-100 border border-brand-gray-200 rounded-sm px-3 py-2 min-h-18 max-h-30'>
+                <textarea
+                  value={state.transitMemo ?? ''}
+                  onChange={(e) => dispatch({ type: 'SET_TRANSIT_MEMO', value: e.target.value })}
+                  placeholder='메모를 입력하세요'
+                  maxLength={100}
+                  className='bg-transparent text-typo-description text-brand-gray-600 w-full outline-none field-sizing-content resize-none placeholder:text-brand-gray-400 min-h-14'
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 추가하기 버튼 */}
+          {error && (
+            <span
+              role='alert'
+              className='text-red-500 text-typo-description text-right'
+            >
+              {error}
+            </span>
+          )}
+          <div className='flex flex-row gap-2 mt-4'>
+            <button
+              onClick={onClose}
+              className={
+                'flex-1 rounded-sm text-center text-brand-gray-500 border text-typo-base-bold border-brand-gray-200 cursor-pointer '
+              }
+            >
+              취소
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={isPending || isCalculating}
+              className={`w-full py-2 rounded-sm flex-3 text-typo-base-bold text-center transition-colors box-border border cursor-pointer hover:bg-brand-blue-800 ${
+                !isPending && !isCalculating
+                  ? 'bg-brand-blue-700 text-white border-brand-gray-300'
+                  : 'bg-brand-gray-200 text-brand-gray-400 border-brand-gray-200 cursor-not-allowed'
+              }`}
+            >
+              {isPending ? '저장 중...' : '저장하기'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+}

--- a/components/features/plan/plan-detail/PlanRouteMemoModal.tsx
+++ b/components/features/plan/plan-detail/PlanRouteMemoModal.tsx
@@ -186,7 +186,8 @@ export default function PlanRouteMemoModal({ planId, item, onClose }: PlanRouteM
                   })}
                 </div>
                 <p className='text-typo-caption text-brand-gray-600 textwrap'>
-                  *한국에서는 대중교통 경로만 제공되며, 출발지와 목적지에 따라 경로가 제공되지 않을 수 있습니다.
+                  *한국에서는 대중교통 경로만 제공되며, 출발지와 목적지의 거리 또는 국가에 따라 경로가 제공되지 않을 수
+                  있습니다.
                 </p>
               </div>
             </div>

--- a/components/features/plan/plan-detail/panelItemDetail/PlanItemCard.tsx
+++ b/components/features/plan/plan-detail/panelItemDetail/PlanItemCard.tsx
@@ -22,8 +22,10 @@ interface PlanItemCardProps {
   onClick: () => void;
   onOpenDetail: () => void;
   onChangeSchedule: () => void;
+  onOpenRouteModal: () => void;
   hasSession: boolean;
   myRole: Role | null;
+  hasNextPlaceItem: boolean;
 }
 
 function CategoryIcon({ category }: { category: string | null }) {
@@ -50,8 +52,10 @@ export default function PlanItemCard({
   onClick,
   onOpenDetail,
   onChangeSchedule,
+  onOpenRouteModal,
   hasSession,
   myRole,
+  hasNextPlaceItem,
 }: PlanItemCardProps) {
   const { open } = useModalStore();
   const queryClient = useQueryClient();
@@ -138,7 +142,7 @@ export default function PlanItemCard({
               {/* 실제로 열릴 드롭다운 메뉴 */}
               <DropDown.Menu>
                 <DropDown.Item onClick={onClick}>일정 편집</DropDown.Item>
-
+                {hasNextPlaceItem && <DropDown.Item onClick={onOpenRouteModal}>이동 정보 관리</DropDown.Item>}
                 <DropDown.Item>
                   {' '}
                   <a
@@ -150,7 +154,9 @@ export default function PlanItemCard({
                     구글 지도에서 보기
                   </a>
                 </DropDown.Item>
+
                 <DropDown.Item onClick={onChangeSchedule}>다른 날짜로 변경</DropDown.Item>
+                <hr className='border-brand-gray-200' />
                 <DropDown.Item onClick={handleDuplicate}>일정 복제</DropDown.Item>
 
                 <DropDown.Item

--- a/components/features/plan/plan-detail/panelItemDetail/TransitInfo.tsx
+++ b/components/features/plan/plan-detail/panelItemDetail/TransitInfo.tsx
@@ -9,28 +9,18 @@ interface TransitInfoProps {
   mode: string;
   time: number | null;
   hasMemo?: boolean;
+  onOpenRouteModal: () => void;
 }
 
-// function CategoryIcon({ category }: { category: string | null }) {
-//   const color = category ? (CATEGORY_COLORS[category as PlaceCategory] ?? '#C0C8E0') : '#C0C8E0';
-//   const emoji = category ? (CATEGORY_EMOJI[category as PlaceCategory] ?? '📍') : '📍';
-
-//   return (
-//     <div
-//       className='flex items-center justify-center rounded-full size-[26px] shrink-0'
-//       style={{ backgroundColor: color }}
-//     >
-//       <span className='font-mona12 text-emoji-sm pl-0.5 pb-0.5'>{emoji}</span>
-//     </div>
-//   );
-// }
-
-export default function TransitInfo({ mode, time, hasMemo }: TransitInfoProps) {
+export default function TransitInfo({ mode, time, hasMemo, onOpenRouteModal }: TransitInfoProps) {
   const modeLabel = TRANSIT_MODE_LABELS[mode as PlanTransitMode] ?? mode;
   const emoji = mode ? (TRANSFORT_EMOJI[mode as PlanTransitMode] ?? '📍') : '📍';
 
   return (
-    <div className='flex gap-2 items-center justify-center'>
+    <div
+      className='flex gap-2 items-center justify-center cursor-pointer'
+      onClick={onOpenRouteModal}
+    >
       <span className='font-mona12 text-emoji-sm pl-0.5 pb-0.5'>{emoji}</span>
 
       <p className='text-typo-description text-white font-light'>

--- a/components/features/plan/plan-detail/panelitem/PlaceItems.tsx
+++ b/components/features/plan/plan-detail/panelitem/PlaceItems.tsx
@@ -1,7 +1,6 @@
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useState } from 'react';
 
-import PlanItemCard from '@/components/features/plan/plan-detail/panelItemDetail/PlanItemCard';
 import { useAddPlanMemoItem } from '@/hooks/plan/useAddPlanMemoItem';
 import { useMovePlanItem } from '@/hooks/plan/useMovePlanItem';
 import { useUpdatePlanItem } from '@/hooks/plan/useUpdatePlanItem';
@@ -10,14 +9,12 @@ import { PlanInfo, PlanItem, PlanSchedule } from '@/types/plan';
 import { Role } from '@/types/shareOption';
 
 import ChangeScheduleModal from '../panelItemDetail/ChangeScheduleModal';
-import PlanItemEditCard from '../panelItemDetail/PlanItemEditCard';
-import PlanMemoItemCard from '../panelItemDetail/PlanMemoItemCard';
 import PlanMemoItemCreateCard from '../panelItemDetail/PlanMemoItemCreateCard';
-import PlanMemoItemEditCard from '../panelItemDetail/PlanMemoItemEditCard';
 import { SortablePlanItem } from '../panelItemDetail/SortablePlanItem';
-import TransitInfo from '../panelItemDetail/TransitInfo';
+import PlanRouteMemoModal from '../PlanRouteMemoModal';
 
 import AddPlaceItem from './AddPlaceItem';
+import PlanScheduleItemRow from './PlanScheduleItemRow';
 
 interface PlanDayPanelProps {
   plan: Pick<PlanInfo, 'title' | 'departureDate' | 'arrivalDate'>;
@@ -46,6 +43,7 @@ export function PlaceItems({
   const [isNewMemoOpen, setIsNewMemoOpen] = useState(false);
   const [changingScheduleItem, setChangingScheduleItem] = useState<PlanItem | null>(null);
   const { mutate: moveToSchedule, isPending: isMoving } = useMovePlanItem({ planId });
+  const [routeModalItemId, setRouteModalItemId] = useState<string | null>(null);
 
   // 장소/메모 수정 훅
   const { addMemoItem, isSubmitting: isAdding } = useAddPlanMemoItem();
@@ -92,6 +90,7 @@ export function PlaceItems({
     const result = await addMemoItem({ scheduleId: schedule.id, ...updated });
     if (result?.success) setIsNewMemoOpen(false);
   };
+
   return (
     <>
       <div
@@ -125,47 +124,22 @@ export function PlaceItems({
                     id={item.id}
                     scheduleId={schedule.id}
                   >
-                    {item.type === 'memo' ? (
-                      editingItemId === item.id ? (
-                        <PlanMemoItemEditCard
-                          item={item}
-                          onClose={() => setEditingItemId(null)}
-                          onSave={(updated) => handleSaveExistingMemo(item, updated)}
-                          isSaving={isUpdating}
-                        />
-                      ) : (
-                        <PlanMemoItemCard
-                          item={item}
-                          onClick={() => setEditingItemId(item.id)}
-                          onChangeSchedule={() => setChangingScheduleItem(item)}
-                          hasSession={hasSession}
-                          myRole={myRole}
-                        />
-                      )
-                    ) : editingItemId === item.id ? (
-                      <PlanItemEditCard
-                        item={item}
-                        onClose={() => setEditingItemId(null)}
-                        onSave={(updated) => handleSavePlaceItem(item, updated)}
-                        isSaving={isUpdating}
-                      />
-                    ) : (
-                      <PlanItemCard
-                        item={item}
-                        onClick={() => setEditingItemId(item.id)}
-                        onOpenDetail={() => onOpenPlaceDetail(item)}
-                        onChangeSchedule={() => setChangingScheduleItem(item)}
-                        hasSession={hasSession}
-                        myRole={myRole}
-                      />
-                    )}
-                    {index < items.length - 1 && item.transitMode && items[index + 1].type !== 'memo' && (
-                      <TransitInfo
-                        mode={item.transitMode}
-                        time={item.transitTime}
-                        hasMemo={!!item.transitMemo}
-                      />
-                    )}
+                    <PlanScheduleItemRow
+                      item={item}
+                      hasNextPlaceItem={index < items.length - 1 && items[index + 1].type === 'place'}
+                      showTransitInfo={index < items.length - 1 && items[index + 1].type !== 'memo'}
+                      isEditing={editingItemId === item.id}
+                      hasSession={hasSession}
+                      myRole={myRole}
+                      isUpdating={isUpdating}
+                      onStartEdit={() => setEditingItemId(item.id)}
+                      onCloseEdit={() => setEditingItemId(null)}
+                      onSavePlace={(updated) => handleSavePlaceItem(item, updated)}
+                      onSaveMemo={(updated) => handleSaveExistingMemo(item, updated)}
+                      onOpenDetail={() => onOpenPlaceDetail(item)}
+                      onChangeSchedule={() => setChangingScheduleItem(item)}
+                      onOpenRouteModal={() => setRouteModalItemId(item.id)}
+                    />
                   </SortablePlanItem>
                 ),
               )}
@@ -201,6 +175,14 @@ export function PlaceItems({
                   );
                 }}
                 isSubmitting={isMoving}
+              />
+            )}
+
+            {routeModalItemId && (
+              <PlanRouteMemoModal
+                planId={planId}
+                item={items.find((i) => i.id === routeModalItemId)!}
+                onClose={() => setRouteModalItemId(null)}
               />
             )}
           </>

--- a/components/features/plan/plan-detail/panelitem/PlanScheduleItemRow.tsx
+++ b/components/features/plan/plan-detail/panelitem/PlanScheduleItemRow.tsx
@@ -1,0 +1,92 @@
+import { PlanItem } from '@/types/plan';
+import { Role } from '@/types/shareOption';
+
+import PlanItemCard from '../panelItemDetail/PlanItemCard';
+import PlanItemEditCard from '../panelItemDetail/PlanItemEditCard';
+import PlanMemoItemCard from '../panelItemDetail/PlanMemoItemCard';
+import PlanMemoItemEditCard from '../panelItemDetail/PlanMemoItemEditCard';
+import TransitInfo from '../panelItemDetail/TransitInfo';
+
+interface PlanScheduleItemRowProps {
+  item: PlanItem;
+  hasNextPlaceItem: boolean;
+  showTransitInfo: boolean;
+  isEditing: boolean;
+  hasSession: boolean;
+  myRole: Role | null;
+  isUpdating: boolean;
+  onStartEdit: () => void;
+  onCloseEdit: () => void;
+  onSavePlace: (updated: { visitTime: string; memoContent: string }) => void;
+  onSaveMemo: (updated: { placeName: string; visitTime: string | null; memoContent: string | null }) => void;
+  onOpenDetail: () => void;
+  onChangeSchedule: () => void;
+  onOpenRouteModal: () => void;
+}
+
+export default function PlanScheduleItemRow({
+  item,
+  hasNextPlaceItem,
+  showTransitInfo,
+  isEditing,
+  hasSession,
+  myRole,
+  isUpdating,
+  onStartEdit,
+  onCloseEdit,
+  onSavePlace,
+  onSaveMemo,
+  onOpenDetail,
+  onChangeSchedule,
+  onOpenRouteModal,
+}: PlanScheduleItemRowProps) {
+  return (
+    <>
+      {item.type === 'memo' ? (
+        isEditing ? (
+          <PlanMemoItemEditCard
+            item={item}
+            onClose={onCloseEdit}
+            onSave={onSaveMemo}
+            isSaving={isUpdating}
+          />
+        ) : (
+          <PlanMemoItemCard
+            item={item}
+            onClick={onStartEdit}
+            onChangeSchedule={onChangeSchedule}
+            hasSession={hasSession}
+            myRole={myRole}
+          />
+        )
+      ) : isEditing ? (
+        <PlanItemEditCard
+          item={item}
+          onClose={onCloseEdit}
+          onSave={onSavePlace}
+          isSaving={isUpdating}
+        />
+      ) : (
+        <PlanItemCard
+          item={item}
+          hasNextPlaceItem={hasNextPlaceItem}
+          onOpenRouteModal={onOpenRouteModal}
+          onClick={onStartEdit}
+          onOpenDetail={onOpenDetail}
+          onChangeSchedule={onChangeSchedule}
+          hasSession={hasSession}
+          myRole={myRole}
+        />
+      )}
+
+      {showTransitInfo && item.transitMode && (
+        <TransitInfo
+          mode={item.transitMode}
+          time={item.transitTime}
+          hasMemo={!!item.transitMemo}
+          onOpenRouteModal={onOpenRouteModal}
+        />
+      )}
+    </>
+  );
+}

--- a/hooks/plan/useUpdateRouteMemo.ts
+++ b/hooks/plan/useUpdateRouteMemo.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updatePlanItemTransitMemo } from '@/lib/actions/planItem';
+import { ActionResult, RpcError } from '@/types/errors';
+
+import { scheduleItemsQueryOptions } from './useGetScheduleItems';
+
+export const useUpdateRouteMemo = ({ planId, scheduleId }: { planId: string; scheduleId: string }) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ActionResult<null>, RpcError, Parameters<typeof updatePlanItemTransitMemo>[0]>({
+    mutationFn: async (params) => {
+      const result = await updatePlanItemTransitMemo(params);
+      if (!result.success) throw new RpcError(result.error.message, result.error.code);
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: scheduleItemsQueryOptions(planId, scheduleId).queryKey });
+    },
+  });
+};

--- a/hooks/plan/useUpdateRouteMemo.ts
+++ b/hooks/plan/useUpdateRouteMemo.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { updatePlanItemTransitMemo } from '@/lib/actions/planItem';
 import { ActionResult, RpcError } from '@/types/errors';
+import { PlanItem } from '@/types/plan';
 
 import { scheduleItemsQueryOptions } from './useGetScheduleItems';
 
@@ -14,8 +15,23 @@ export const useUpdateRouteMemo = ({ planId, scheduleId }: { planId: string; sch
       if (!result.success) throw new RpcError(result.error.message, result.error.code);
       return result;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: scheduleItemsQueryOptions(planId, scheduleId).queryKey });
+    onSuccess: (_, variables) => {
+      const queryKey = scheduleItemsQueryOptions(planId, scheduleId).queryKey;
+
+      queryClient.setQueryData<PlanItem[]>(queryKey, (old) => {
+        if (!old) return old;
+        return old.map((item) =>
+          item.id === variables.placeId
+            ? {
+                ...item,
+                transitMode: variables.transitMode,
+                transitDistance: variables.transitDistance,
+                transitTime: variables.transitTime,
+                transitMemo: variables.transitMemo,
+              }
+            : item,
+        );
+      });
     },
   });
 };

--- a/hooks/plan/useUpdateRouteMemoForm.ts
+++ b/hooks/plan/useUpdateRouteMemoForm.ts
@@ -1,0 +1,114 @@
+import { useReducer, useState } from 'react';
+
+import { PlanTransitMode } from '@/types/plan';
+
+import { useUpdateRouteMemo } from './useUpdateRouteMemo';
+
+interface UpdateTransitState {
+  transitMode: PlanTransitMode;
+  transitDistance: number | null;
+  transitTime: number | null;
+  transitMemo: string | null;
+  isPending: boolean;
+  submitError: string | null;
+}
+
+type UpdateTransitAction =
+  | { type: 'SET_TRANSIT_MODE'; value: PlanTransitMode }
+  | { type: 'SET_TRANSIT_DISTANCE'; value: number | null }
+  | { type: 'SET_TRANSIT_TIME'; value: number | null }
+  | { type: 'SET_TRANSIT_MEMO'; value: string }
+  | { type: 'SUBMIT_START' }
+  | { type: 'SUBMIT_SUCCESS' }
+  | { type: 'SUBMIT_ERROR'; error: string }
+  | { type: 'RESET' };
+
+const initialState: UpdateTransitState = {
+  transitMode: 'transit',
+  transitDistance: null,
+  transitTime: null,
+  transitMemo: '',
+  isPending: false,
+  submitError: null,
+};
+
+function reducer(state: UpdateTransitState, action: UpdateTransitAction): UpdateTransitState {
+  switch (action.type) {
+    case 'SET_TRANSIT_MODE':
+      return { ...state, transitMode: action.value };
+    case 'SET_TRANSIT_DISTANCE':
+      return { ...state, transitDistance: action.value };
+    case 'SET_TRANSIT_TIME':
+      return { ...state, transitTime: action.value };
+
+    case 'SET_TRANSIT_MEMO':
+      return { ...state, transitMemo: action.value };
+    case 'SUBMIT_START':
+      return { ...state, isPending: true, submitError: null };
+    case 'SUBMIT_SUCCESS':
+      return {
+        ...state,
+        isPending: false,
+      };
+    case 'SUBMIT_ERROR':
+      return { ...state, isPending: false, submitError: action.error };
+    case 'RESET':
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+const validate = (state: UpdateTransitState): string | null => {
+  if (!state.transitMode) {
+    return '이동수단을 선택해주세요.';
+  }
+
+  return null;
+};
+
+export function useUpdateRouteMemoForm(
+  planId: string,
+  scheduleId: string,
+  placeId: string,
+  initial?: Partial<UpdateTransitState>,
+) {
+  const [state, dispatch] = useReducer(reducer, initial, (init) => ({ ...initialState, ...init }));
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const { mutate, isPending, error: mutationError } = useUpdateRouteMemo({ planId, scheduleId });
+
+  const submitToServer = () => {
+    dispatch({ type: 'SUBMIT_START' });
+
+    mutate(
+      {
+        placeId,
+        transitMode: state.transitMode,
+        transitDistance: state.transitDistance,
+        transitTime: state.transitTime,
+        transitMemo: state.transitMemo,
+      },
+      {
+        onSuccess: (result) => {
+          if (result.success) dispatch({ type: 'SUBMIT_SUCCESS' });
+          else dispatch({ type: 'SUBMIT_ERROR', error: '수정에 실패했습니다.' });
+        },
+        onError: () => dispatch({ type: 'SUBMIT_ERROR', error: '수정 중 오류가 발생했습니다.' }),
+      },
+    );
+  };
+
+  const handleSubmit = () => {
+    const error = validate(state);
+    if (error) {
+      setValidationError(error);
+      dispatch({ type: 'SUBMIT_ERROR', error });
+      return;
+    }
+    setValidationError(null);
+
+    submitToServer();
+  };
+
+  return { state, dispatch, handleSubmit, isPending, error: validationError ?? mutationError?.message ?? null };
+}

--- a/hooks/useNewPlaceForm.ts
+++ b/hooks/useNewPlaceForm.ts
@@ -1,9 +1,11 @@
 'use client';
 
 import { useState, useReducer } from 'react';
-import { SelectedGooglePlace } from '@/types/googleSearchApiDetail';
-import { useCreatePlace } from './new-place/useCreatePlace';
+
 import { sanitizeBusinessStatus, type PlaceCategory } from '@/types/corePlace';
+import { SelectedGooglePlace } from '@/types/googleSearchApiDetail';
+
+import { useCreatePlace } from './new-place/useCreatePlace';
 
 export interface NewPlaceFormState {
   korean_name: string;
@@ -60,7 +62,13 @@ const getInitialState = (place: SelectedGooglePlace): NewPlaceFormState => {
   };
 };
 
-export const checkIsKorean = (lat: number, lng: number) => lat >= 33 && lat <= 39 && lng >= 124 && lng <= 132;
+export const checkIsKorean = (lat: number, lng: number) => {
+  // 후쿠오카/대마도 등 일본 서남부 지역 명시적 제외
+  const isKyushuArea = lat >= 33.0 && lat <= 34.0 && lng >= 129.5 && lng <= 131.0;
+  if (isKyushuArea) return false;
+
+  return lat >= 33 && lat <= 39 && lng >= 124 && lng <= 132;
+};
 
 // 검증
 const validate = (state: NewPlaceFormState, isKorean: boolean): string | null => {

--- a/lib/actions/planItem.ts
+++ b/lib/actions/planItem.ts
@@ -465,3 +465,34 @@ export const pastePlanItems = async (
 
   return { success: true, data: null };
 };
+
+interface UpdatePlanItemTransitMemoProps {
+  placeId: string;
+  transitMode: PlanTransitMode;
+  transitDistance: number | null;
+  transitTime: number | null;
+  transitMemo: string | null;
+}
+
+export const updatePlanItemTransitMemo = async (
+  params: UpdatePlanItemTransitMemoProps,
+): Promise<ActionResult<null>> => {
+  const { placeId, transitMode, transitDistance, transitTime, transitMemo } = params;
+  const supabase = await supabaseUser();
+
+  const { error } = await supabase.rpc('update_plan_item_transit_memo', {
+    p_item_id: placeId,
+    p_transit_time: transitTime,
+    p_transit_distance: transitDistance !== null ? transitDistance / 1000 : null,
+    p_transit_mode: transitMode,
+    p_transit_memo: transitMemo,
+  });
+
+  if (error) {
+    return {
+      success: false,
+      error: { message: SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR', code: error.code },
+    };
+  }
+  return { success: true, data: null };
+};

--- a/lib/utils/getGoogleMapsDirectionUrl.ts
+++ b/lib/utils/getGoogleMapsDirectionUrl.ts
@@ -1,0 +1,25 @@
+import { PlanTransitMode } from '@/types/plan';
+
+const GOOGLE_MAPS_URL_TRAVEL_MODE: Record<PlanTransitMode, string> = {
+  walking: 'walking',
+  cycling: 'bicycling',
+  driving: 'driving',
+  transit: 'transit',
+};
+
+export function buildGoogleMapsDirectionsUrl(
+  origin: { lat: number; lng: number; googlePlaceId: string | null; name: string },
+  destination: { lat: number; lng: number; googlePlaceId: string | null; name: string },
+  mode: PlanTransitMode,
+): string {
+  const params = new URLSearchParams({
+    api: '1',
+    origin: origin.name ?? `${origin.lat},${origin.lng}`,
+    destination: destination.name ?? `${destination.lat},${destination.lng}`,
+    travelmode: GOOGLE_MAPS_URL_TRAVEL_MODE[mode],
+  });
+  if (origin.googlePlaceId) params.set('origin_place_id', origin.googlePlaceId);
+  if (destination.googlePlaceId) params.set('destination_place_id', destination.googlePlaceId);
+
+  return `https://www.google.com/maps/dir/?${params.toString()}`;
+}

--- a/lib/utils/googleRoutes.ts
+++ b/lib/utils/googleRoutes.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { PlanTransitMode, VEHICLE_TO_TRAVEL_MODE } from '@/types/plan';
 
 export interface RouteResult {

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -57,10 +57,10 @@ export interface PlanDetail {
 export type PlanTransitMode = 'walking' | 'cycling' | 'driving' | 'transit';
 
 export const TRANSIT_MODE_LABELS: Record<PlanTransitMode, string> = {
+  transit: '대중교통',
   walking: '도보',
   cycling: '자전거',
-  driving: '자가용',
-  transit: '대중교통',
+  driving: '자동차',
 };
 
 export const VEHICLE_TO_TRAVEL_MODE: Record<PlanTransitMode, string> = {


### PR DESCRIPTION
## 🛠️ 과제 요약

- 일정 아이템 사이의 이동 정보(이동수단/거리/시간/메모)를 수정할 수 있는 `RouteModal`을 구현했습니다. 
- `TransitInfo`(이동 정보 표시줄) 클릭과 아이템 드롭다운의 "이동 정보 수정" 메뉴, 두 경로에서 진입할 수 있습니다.

## 📝 요구 사항과 구현 내용

<img width="857" height="645" alt="Frame 433" src="https://github.com/user-attachments/assets/603b471c-a7d2-44d2-96f0-72e10685b3d3" />


### 1️⃣ 데이터 흐름

- 별도 서버 조회 없이, 모달을 열 때 `queryClient.getQueryData`로 이미 로드된 캐시에서 `currentItem`(출발지)과 그 다음 `place` 타입 아이템(`nextItem`, 도착지)을 직접 찾아 사용
- 이동수단 버튼을 클릭 시 `getRouteDistance`로 새 경로를 계산해 거리/시간을 갱신
- 저장 시 이동수단/거리/시간/메모를 한 번에 업데이트

### 2️⃣ 구조 — `useUpdateTransitForm`,  `update_plan_item_transit_memo` RPC

- 기존 `useUpdatePlanInfoForm`/`useNewPlaceForm`과 동일한 아키텍처(reducer + dispatch, `validate`, mutation 연동)
- 초기값은 `currentItem`의 기존 데이터(이동수단/거리/시간/메모)
- `transitDistance`/`transitTime`을 `number`가 아닌 `number | null`로 설계해 "아직 계산 안 됨"과 "실제 값 0"을 구분
- **RPC**: 대상 아이템의 이동수단/거리/시간/메모를 한 번에 갱신합니다.
- `transit_memo` 컬럼이 `varchar(100)` 제약이 있어, 프론트 `textarea`에도 `maxLength={100}` 적용
- `useUpdateRouteMemo`의 성공 시 처리를 전체 리스트 `invalidateQueries`가 아니라, 변경된 값이 이미 클라이언트에 확정되어 있으므로 `setQueryData`로 해당 아이템 하나만 직접 갱신하도록 변경 — 불필요한 재조회와 리스트 전체 리렌더 방지

### 부가 기능

- **한국 지역 이동수단 제한**: 출발지 좌표가 한국 영역 안이면 대중교통(`transit`) 외 이동수단 버튼을 비활성화(기존 "한국은 DRIVE 미지원" 정책과 일관)
- **구글 지도 길찾기 연동**: 이동 정보 아이콘 클릭 시 Google Maps Directions URL로 새 탭 오픈 — `origin_place_id`/`destination_place_id`로 정확한 장소를 지정하고, `origin`/`destination` 파라미터에는 좌표 대신 장소 이름을 넣어 결과 화면에 좌표 대신 장소명이 표시되도록 처리
- **드롭다운/TransitInfo 노출 조건**: "다음 아이템이 실제 장소인지" 여부로 "이동 정보 수정" 메뉴와 `TransitInfo` 표시 여부를 판단 
-  `PlaceItems` 컴포넌트 보여주는 분기를 `PlanScheduleItemRow`라는 단일 컴포넌트로 통합


## 💬 PR 포인트 & 궁금한 점

### 테스트 방법

- `TransitInfo` 클릭, 드롭다운의 "이동 정보 수정" 클릭 양쪽에서 모달이 정상적으로 열리는지 확인
- 이동수단을 변경했을 때 거리/시간이 실시간으로 재계산되어 표시되는지 확인
- 메모를 입력하고 저장 시, 이동수단/거리/시간과 함께 정상 반영되는지, 화면(TransitInfo)에도 즉시 갱신되는지 확인
- 100자를 초과하는 메모 입력이 제한되는지 확인
- 한국 내 장소 간 이동일 때 대중교통 외 버튼이 비활성화되는지 확인
- 구글 지도 아이콘 클릭 시 정확한 두 지점 간 경로로 새 탭이 열리는지, 결과 화면에 좌표가 아닌 장소명이 표시되는지 확인
- 다음 자리에 장소가 없는 아이템(리스트 마지막, 다음이 메모인 경우)에서는 "이동 정보 수정" 메뉴와 `TransitInfo`가 노출되지 않는지 확인

## 🔗 연관된 이슈

- close #133
