### PR TITLE
Fix: useSyncExternalStore을 통해 빌드 에러 해결

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
           />
         </div>
         <div className='flex flex-col gap-2.5 z-10 mt-43'>
-          <InfoTomato onClick={() => setIsModalClosedByUser(true)} />
+          <InfoTomato onClick={() => setIsModalClosedByUser(false)} />
           <JoinPlanButton variant='primary' />
           <LoginButton />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
           />
         </div>
         <div className='flex flex-col gap-2.5 z-10 mt-43'>
-          <InfoTomato onClick={() => setIsInfoModalOpen(false)} />
+          <InfoTomato onClick={() => setIsInfoModalOpen(true)} />
           <JoinPlanButton variant='primary' />
           <LoginButton />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,9 +8,12 @@ import InfoContainerModal from '@/components/features/info/InfoContainerModal';
 import InfoTomato from '@/components/features/info/InfoTomato';
 import JoinPlanButton from '@/components/features/JoinPlanButton';
 import LoginButton from '@/components/features/LoginButton';
+import { useIsMounted } from '@/hooks/useIsMounted';
 
 export default function Home() {
-  const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
+  const isMounted = useIsMounted();
+  const [isModalClosedByUser, setIsModalClosedByUser] = useState(false);
+  const isInfoModalOpen = isMounted && !isModalClosedByUser;
 
   return (
     <div className='bg-brand-blue-50 w-screen h-screen relative overflow-hidden'>
@@ -33,7 +36,7 @@ export default function Home() {
           />
         </div>
         <div className='flex flex-col gap-2.5 z-10 mt-43'>
-          <InfoTomato onClick={() => setIsInfoModalOpen(true)} />
+          <InfoTomato onClick={() => setIsModalClosedByUser(true)} />
           <JoinPlanButton variant='primary' />
           <LoginButton />
         </div>
@@ -87,7 +90,7 @@ export default function Home() {
         className='absolute w-[38vw] h-auto right-[2%] bottom-0 z-1'
       />
 
-      {isInfoModalOpen && <InfoContainerModal onClose={() => setIsInfoModalOpen(false)} />}
+      {isInfoModalOpen && <InfoContainerModal onClose={() => setIsModalClosedByUser(false)} />}
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -90,7 +90,7 @@ export default function Home() {
         className='absolute w-[38vw] h-auto right-[2%] bottom-0 z-1'
       />
 
-      {isInfoModalOpen && <InfoContainerModal onClose={() => setIsModalClosedByUser(false)} />}
+      {isInfoModalOpen && <InfoContainerModal onClose={() => setIsModalClosedByUser(true)} />}
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,8 @@ import JoinPlanButton from '@/components/features/JoinPlanButton';
 import LoginButton from '@/components/features/LoginButton';
 
 export default function Home() {
-  const [isInfoModalOpen, setIsInfoModalOpen] = useState(true);
+  const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
+
   return (
     <div className='bg-brand-blue-50 w-screen h-screen relative overflow-hidden'>
       <div className='w-full h-full flex flex-col items-center justify-center'>
@@ -32,7 +33,7 @@ export default function Home() {
           />
         </div>
         <div className='flex flex-col gap-2.5 z-10 mt-43'>
-          <InfoTomato onClick={() => setIsInfoModalOpen(true)} />
+          <InfoTomato onClick={() => setIsInfoModalOpen(false)} />
           <JoinPlanButton variant='primary' />
           <LoginButton />
         </div>

--- a/components/features/info/InfoContainerModal.tsx
+++ b/components/features/info/InfoContainerModal.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 
 import { Icon } from '@/components/common/Icon';
 import ModalHeader from '@/components/features/place/save/modal-item/ModalHeader';
+import { useIsMounted } from '@/hooks/useIsMounted';
 
 import { InfoSteps } from './InfoSteps';
 
@@ -15,6 +16,10 @@ export default function InfoContainerModal({ onClose }: InfoModalProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const total = InfoSteps.length;
   const current = InfoSteps[currentIndex];
+
+  const isMounted = useIsMounted();
+
+  if (!isMounted) return null;
 
   const handleNext = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();

--- a/components/features/info/InfoContainerModal.tsx
+++ b/components/features/info/InfoContainerModal.tsx
@@ -17,7 +17,7 @@ export default function InfoContainerModal({ onClose }: InfoModalProps) {
   const total = InfoSteps.length;
   const current = InfoSteps[currentIndex];
 
-  const isMounted = useIsMounted(); // 여기서만 필요 — document 참조를 서버에서 막기 위함
+  const isMounted = useIsMounted();
   if (!isMounted) return null;
 
   const handleNext = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/components/features/info/InfoContainerModal.tsx
+++ b/components/features/info/InfoContainerModal.tsx
@@ -17,8 +17,7 @@ export default function InfoContainerModal({ onClose }: InfoModalProps) {
   const total = InfoSteps.length;
   const current = InfoSteps[currentIndex];
 
-  const isMounted = useIsMounted();
-
+  const isMounted = useIsMounted(); // 여기서만 필요 — document 참조를 서버에서 막기 위함
   if (!isMounted) return null;
 
   const handleNext = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/components/features/info/InfoSteps.tsx
+++ b/components/features/info/InfoSteps.tsx
@@ -16,7 +16,7 @@ export const InfoSteps: InfoStep[] = [
           <Image
             src='/images/info_plan.jpg'
             alt='로비 화면'
-            className='w-full h-full object-cover'
+            className='w-full h-full object-cover rounded-lg'
             height={144}
             width={340}
           />
@@ -61,7 +61,7 @@ export const InfoSteps: InfoStep[] = [
           <Image
             src='/images/info_list.jpg'
             alt='장소 리스트 화면'
-            className='w-full h-full object-cover'
+            className='w-full h-full object-cover rounded-lg'
             height={144}
             width={340}
           />
@@ -101,9 +101,9 @@ export const InfoSteps: InfoStep[] = [
       <InfoSlideBody
         media={
           <Image
-            src='/images/info_list.jpg'
+            src='/images/info_search.jpg'
             alt='장소 검색 화면'
-            className='w-full h-full object-cover'
+            className='w-full h-full object-cover rounded-lg'
             height={144}
             width={340}
           />
@@ -138,7 +138,7 @@ export const InfoSteps: InfoStep[] = [
           <Image
             src='/images/info_lobby.jpg'
             alt='로비 화면'
-            className='w-full h-full object-cover'
+            className='w-full h-full object-cover rounded-lg'
             height={144}
             width={340}
           />

--- a/hooks/useIsMounted.ts
+++ b/hooks/useIsMounted.ts
@@ -1,0 +1,11 @@
+import { useSyncExternalStore } from 'react';
+
+const emptySubscribe = () => () => {};
+
+export function useIsMounted() {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true, // 클라이언트에서 렌더링될 때의 값
+    () => false, // 서버(SSR/빌드)에서 렌더링될 때의 값
+  );
+}


### PR DESCRIPTION
## 🛠️ 문제상황

소개 모달을 첫 화면에 자동으로 띄우려고 초기값을 true로 바꿨더니, 빌드(정적 프리렌더링) 시점에 document is not defined 에러로 배포가 실패했습니다.

## 📝 해결방법

useSyncExternalStore로 클라이언트 마운트 여부를 구독하는 useIsMounted 훅을 만들어, 두 군데에서 재사용했습니다.

```
// hooks/useIsMounted.ts
import { useSyncExternalStore } from 'react';

export function useIsMounted() {
  return useSyncExternalStore(
    () => () => {},
    () => true,
    () => false,
  );
}
```

#### 1. InfoContainerModal — document 참조가 서버에서 실행되지 않도록 가드
```
const isMounted = useIsMounted();
if (!isMounted) return null;

return createPortal(..., document.body);
```

#### 2. Home — 모달을 여는 시점을 useEffect + setState로 직접 트리거하지 않고, isMounted와 사용자 액션을 조합한 파생값으로 계산

서버/빌드 시점엔 isMounted가 false라 모달이 아예 렌더링되지 않고, 클라이언트 마운트 후 자동으로 true가 되어 모달이 열립니다. useEffect 안에서 setState를 호출하는 코드가 없어져서 react-hooks/set-state-in-effect 린트 경고도 해결됩니다.
```
const isMounted = useIsMounted();
const [isModalClosedByUser, setIsModalClosedByUser] = useState(false);
const isInfoModalOpen = isMounted && !isModalClosedByUser;

{isInfoModalOpen && <InfoContainerModal onClose={() => setIsModalClosedByUser(true)} />}
```

## 테스트
- npm run build 정상 완료 확인
- 첫 화면 진입 시 모달 자동 노출, 닫기 버튼 정상 동작 확인