### PR TITLE
[L_008, 009, 015] 장소 리스트 페이지 태그 추가 및 태그 관리 모달 구현 / 전역 모달 마우스 이벤트 조정 및 가로 스크롤 훅 휠 이벤트 조정

### DIFF
--- a/assets/icons/check.svg
+++ b/assets/icons/check.svg
@@ -1,3 +1,3 @@
 <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M15 4.5L6.75 12.75L3 9" stroke="#3676F5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 4.5L6.75 12.75L3 9" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/components/common/Dropdown/Menu.tsx
+++ b/components/common/Dropdown/Menu.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import { createPortal } from 'react-dom';
+
 import { useDropdown } from './DropdownContext';
 
 interface DropDownMenuProps {
   children: React.ReactNode;
   minWidth?: boolean;
+  className?: string;
 }
 
-export default function DropDownMenu({ children, minWidth = true }: DropDownMenuProps) {
+export default function DropDownMenu({ children, minWidth = true, className }: DropDownMenuProps) {
   const { isOpen, setFloating, floatingStyles, getFloatingProps } = useDropdown();
 
   if (!isOpen) return null;
@@ -17,7 +19,9 @@ export default function DropDownMenu({ children, minWidth = true }: DropDownMenu
     <div
       ref={setFloating}
       style={floatingStyles}
-      className={`flex flex-col bg-white rounded-lg shadow-md ${minWidth ? 'min-w-60.25' : ''} z-100 p-2 gap-1`}
+      className={
+        className || `flex flex-col bg-white rounded-lg shadow-md ${minWidth ? 'min-w-60.25' : ''} z-100 p-2 gap-1`
+      }
       {...getFloatingProps()}
     >
       {children}

--- a/components/common/Modal/GlobalModal.tsx
+++ b/components/common/Modal/GlobalModal.tsx
@@ -2,6 +2,7 @@
 
 import CancelSignupModal from '@/components/features/CancelSignupModal';
 import CancelNewPlaceModal from '@/components/features/new-place/CancelNewPlaceModal';
+import TagModal from '@/components/features/place-list/tag/TagModal';
 import DeletePlanDateModal from '@/components/features/plan/plan-detail/DeletePlanDateModal';
 import DeletePlanItemModal from '@/components/features/plan/plan-detail/DeletePlanItemModal';
 import { useModalStore } from '@/lib/store/modalStore';
@@ -65,6 +66,7 @@ export default function GlobalModal() {
           type={activeModal.props.type}
         />
       )}
+      {activeModal.type === 'tag' && <TagModal listId={activeModal.props.listId} />}
     </div>
   );
 }

--- a/components/common/Modal/GlobalModal.tsx
+++ b/components/common/Modal/GlobalModal.tsx
@@ -5,6 +5,7 @@ import CancelNewPlaceModal from '@/components/features/new-place/CancelNewPlaceM
 import TagModal from '@/components/features/place-list/tag/TagModal';
 import DeletePlanDateModal from '@/components/features/plan/plan-detail/DeletePlanDateModal';
 import DeletePlanItemModal from '@/components/features/plan/plan-detail/DeletePlanItemModal';
+import { useModalControl } from '@/hooks/useModalControl';
 import { useModalStore } from '@/lib/store/modalStore';
 
 import EnterInviteLinkModal from '../../features/plan/EnterInviteLinkModal';
@@ -22,13 +23,15 @@ import ShareLinkModal from '../ShareLinkModal';
 
 export default function GlobalModal() {
   const { activeModal, close } = useModalStore();
+  const { handleMouseDown, handleMouseUp } = useModalControl(close);
 
   if (!activeModal) return null;
 
   return (
     <div
       className='modal-overlay'
-      onClick={close}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
     >
       {activeModal.type === 'enterInviteLink' && <EnterInviteLinkModal type={activeModal.props.type} />}
       {activeModal.type === 'cancelSignup' && <CancelSignupModal />}

--- a/components/features/CountrySelect.tsx
+++ b/components/features/CountrySelect.tsx
@@ -120,7 +120,7 @@ export default function CountrySelect({ value, onChange }: Props) {
               >
                 {nation.label}
                 {value.countryCode === nation.countryCode && (
-                  <span className='absolute inset-y-0 right-0 flex items-center pr-4'>
+                  <span className='absolute inset-y-0 right-0 flex items-center pr-4 text-brand-blue-500'>
                     <Icon
                       name='Check'
                       size={16}

--- a/components/features/new-place/form-inputs/FormTypeSelect.tsx
+++ b/components/features/new-place/form-inputs/FormTypeSelect.tsx
@@ -94,7 +94,7 @@ export default function FormTypeSelect({
               >
                 {option.label}
                 {value === option.value && (
-                  <span className='absolute inset-y-0 right-0 flex items-center pr-4'>
+                  <span className='absolute inset-y-0 right-0 flex items-center pr-4 text-brand-blue-500'>
                     <Icon
                       name='Check'
                       size={16}

--- a/components/features/new-plan/plan-answer/form-inputs/FormTypeSelect.tsx
+++ b/components/features/new-plan/plan-answer/form-inputs/FormTypeSelect.tsx
@@ -178,7 +178,7 @@ export default function FormTypeSelect({
                         >
                           {option.label}
                           {option.value === value && (
-                            <span className='absolute inset-y-0 right-0 flex items-center pr-4'>
+                            <span className='absolute inset-y-0 right-0 flex items-center pr-4 text-brand-blue-500'>
                               <Icon
                                 name='Check'
                                 size={16}

--- a/components/features/place-list/PlaceListDropdownMenu.tsx
+++ b/components/features/place-list/PlaceListDropdownMenu.tsx
@@ -47,6 +47,10 @@ export default function PlaceListDropdownMenu({ id, type = 'overview', listName,
         </DropDown.Trigger>
 
         <DropDown.Menu>
+          {type === 'detail' && (
+            <DropDown.Item onClick={() => router.push(`/places/${id}/edit`)}>리스트 편집</DropDown.Item>
+          )}
+          <DropDown.Item onClick={() => setShareOptionModalOpen(true)}>공유 옵션 관리</DropDown.Item>
           <DropDown.Item
             onClick={() => {
               open({ type: 'shareLink', props: { type: 'VIEW', link: createViewLink(id, 'place_list') } });
@@ -60,10 +64,6 @@ export default function PlaceListDropdownMenu({ id, type = 'overview', listName,
           >
             수정할 수 있도록 초대
           </DropDown.Item>
-          <DropDown.Item onClick={() => setShareOptionModalOpen(true)}>공유 옵션 관리</DropDown.Item>
-          {type === 'detail' && (
-            <DropDown.Item onClick={() => router.push(`/places/${id}/edit`)}>리스트 편집</DropDown.Item>
-          )}
           {isMaster && (
             <DropDown.Item onClick={() => confirmDeletePlaceList(listName, id, type === 'detail')}>
               리스트 삭제

--- a/components/features/place-list/PlaceListShareOptionModal.tsx
+++ b/components/features/place-list/PlaceListShareOptionModal.tsx
@@ -4,14 +4,18 @@ import { Icon } from '@/components/common/Icon';
 import Loader from '@/components/common/Loader';
 import ShareOptionContent from '@/components/common/ShareOption/ShareOptionContent';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
+import { useModalControl } from '@/hooks/useModalControl';
 
 export default function PlaceListShareOptionModal({ id, onClose }: { id: string; onClose: () => void }) {
+  const { handleMouseDown, handleMouseUp } = useModalControl(onClose);
+
   return createPortal(
     <div
       className='modal-overlay'
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
       onClick={(e) => {
         e.stopPropagation();
-        onClose();
       }}
     >
       <div

--- a/components/features/place-list/detail/PlaceItem.tsx
+++ b/components/features/place-list/detail/PlaceItem.tsx
@@ -8,21 +8,25 @@ import { useConfirmDeletePlace } from '@/hooks/place-list/useConfirmDeletePlace'
 import { useGetMyRole } from '@/hooks/place-list/useGetMyRole';
 import { useUpdatePlace } from '@/hooks/place-list/useUpdatePlace';
 import { getPlaceCategoryLabel } from '@/lib/utils/categoryLabel';
-import { Place } from '@/types/placeList';
+import { Place, Tag } from '@/types/placeList';
 
 import AuthorityWrapper from '../../AuthorityWrapper';
+import PlaceTag from '../tag/PlaceTag';
 
 export default function PlaceItem({
   place,
   listId,
   onClickItem,
+  listTags,
 }: {
   place: Place;
   listId: string;
   onClickItem: (id: string) => void;
+  listTags: Tag[];
 }) {
   const [isEdit, setIsEdit] = useState(false);
   const [memo, setMemo] = useState<string | null>(place.memoContent);
+  const [tags, setTags] = useState<Set<string>>(() => new Set(place.tags.map((tag) => tag.id)));
   const { confirmDeletePlaceList } = useConfirmDeletePlace(listId);
   const { data: myRole } = useGetMyRole(listId);
   const { mutate: updatePlace } = useUpdatePlace(listId);
@@ -34,7 +38,19 @@ export default function PlaceItem({
   };
 
   const handleEdit = () => {
-    updatePlace({ placeId: place.id, memo }, { onSuccess: () => setIsEdit(false) });
+    updatePlace({ placeId: place.id, memo, tags: Array.from(tags) }, { onSuccess: () => setIsEdit(false) });
+  };
+
+  const handleToggleTag = (id: string) => {
+    setTags((prev) => {
+      const update = new Set(prev);
+      if (update.has(id)) {
+        update.delete(id);
+      } else {
+        update.add(id);
+      }
+      return update;
+    });
   };
 
   return (
@@ -96,8 +112,7 @@ export default function PlaceItem({
               <p className='text-brand-gray-600 text-typo-description whitespace-pre-wrap'>{place.memoContent}</p>
             )}
 
-            {/* TODO: 2차 MVP 때 태그 적용 */}
-            {/* <div className='flex gap-1 items-center overflow flex-wrap'>
+            <div className='flex gap-1 items-center overflow flex-wrap'>
               {place.tags.map((item) => (
                 <PlaceTag
                   key={item.id}
@@ -105,16 +120,28 @@ export default function PlaceItem({
                   isRounded={true}
                 />
               ))}
-            </div> */}
+            </div>
           </>
         ) : (
-          <div>
+          <div className='flex flex-col gap-2'>
             <textarea
               placeholder='메모 추가'
               value={memo ?? ''}
               className='bg-brand-gray-100 hover:bg-brand-gray-200 min-h-16 text-typo-base px-3 py-2 text-brand-gray-600 border border-brand-gray-200 outline-none rounded-sm w-full resize-none field-sizing-content'
               onChange={(e) => setMemo(e.target.value)}
             />
+
+            <div className='flex gap-1 items-center overflow flex-wrap'>
+              {listTags.map((item) => (
+                <PlaceTag
+                  key={item.id}
+                  tag={item}
+                  isEdit={true}
+                  isSelected={tags.has(item.id)}
+                  onClick={() => handleToggleTag(item.id)}
+                />
+              ))}
+            </div>
 
             <div className='text-typo-base flex gap-1.5 font-light'>
               <button

--- a/components/features/place-list/detail/PlaceListDetailWrapper.tsx
+++ b/components/features/place-list/detail/PlaceListDetailWrapper.tsx
@@ -13,6 +13,19 @@ import SortingDropdownButton from './SortingDropdownButton';
 
 export default function PlaceListDetailWrapper({ listId }: { listId: string }) {
   const [sortBy, setSortBy] = useState<SortType>('created_desc');
+  const [activeTagIds, setActiveTagIds] = useState<Set<string>>(new Set());
+
+  const handleToggleTag = (id: string) => {
+    setActiveTagIds((prev) => {
+      const updated = new Set(prev);
+      if (prev.has(id)) {
+        updated.delete(id);
+      } else {
+        updated.add(id);
+      }
+      return updated;
+    });
+  };
 
   return (
     <div className='flex flex-col gap-2.5 h-full'>
@@ -28,7 +41,11 @@ export default function PlaceListDetailWrapper({ listId }: { listId: string }) {
             onSortChange={setSortBy}
           />
           <QueryBoundary subject='태그'>
-            <TagList listId={listId} />
+            <TagList
+              listId={listId}
+              activeTagIds={activeTagIds}
+              onToggleTag={handleToggleTag}
+            />
           </QueryBoundary>
         </div>
       </div>
@@ -39,6 +56,7 @@ export default function PlaceListDetailWrapper({ listId }: { listId: string }) {
           <PlaceListPlaces
             listId={listId}
             sortBy={sortBy}
+            activeTagIds={activeTagIds}
           />
         </QueryBoundary>
       </div>

--- a/components/features/place-list/detail/PlaceListDetailWrapper.tsx
+++ b/components/features/place-list/detail/PlaceListDetailWrapper.tsx
@@ -5,6 +5,8 @@ import { useState } from 'react';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import { SortType } from '@/types/placeList';
 
+import TagList from '../tag/TagList';
+
 import PlaceListHeader from './PlaceListHeader';
 import PlaceListPlaces from './PlaceListPlaces';
 import SortingDropdownButton from './SortingDropdownButton';
@@ -25,9 +27,9 @@ export default function PlaceListDetailWrapper({ listId }: { listId: string }) {
             sortBy={sortBy}
             onSortChange={setSortBy}
           />
-          {/* <QueryBoundary subject='태그'>
-                <TagList listId={listId} />
-              </QueryBoundary> */}
+          <QueryBoundary subject='태그'>
+            <TagList listId={listId} />
+          </QueryBoundary>
         </div>
       </div>
 

--- a/components/features/place-list/detail/PlaceListPlaces.tsx
+++ b/components/features/place-list/detail/PlaceListPlaces.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
 import { useOpenPlaceDetailModal } from '@/hooks/place/useOpenPlaceDetailModal';
 import { useGetPlaceListPlaces } from '@/hooks/place-list/useGetPlaceListPlaces';
+import { useGetPlaceListTags } from '@/hooks/place-list/useGetPlaceListTags';
 import { SortType } from '@/types/placeList';
 
 import EmptyState from '../../../common/EmptyState';
@@ -13,12 +14,28 @@ import CorePlaceDetailContainer from '../../place/CorePlaceDetailContainer';
 
 import PlaceItem from './PlaceItem';
 
-export default function PlaceListPlaces({ listId, sortBy }: { listId: string; sortBy: SortType }) {
+export default function PlaceListPlaces({
+  listId,
+  sortBy,
+  activeTagIds,
+}: {
+  listId: string;
+  sortBy: SortType;
+  activeTagIds: Set<string>;
+}) {
   const { data, isFetchingNextPage, hasNextPage, fetchNextPage, isFetchNextPageError } = useGetPlaceListPlaces({
     listId,
     sortBy,
   });
+
+  // 태그 필터링
+  const filteredPlaces = useMemo(() => {
+    if (activeTagIds.size === 0) return data;
+    return data.filter((place) => place.tags.some((tag) => activeTagIds.has(tag.id)));
+  }, [activeTagIds, data]);
+
   const { isOpenPlaceModal, selectedId, handleClickPlaceItem, handleClosePlaceDetailModal } = useOpenPlaceDetailModal();
+  const { data: tags } = useGetPlaceListTags(listId);
 
   const observerTargetRef = useRef<HTMLDivElement | null>(null);
 
@@ -45,12 +62,13 @@ export default function PlaceListPlaces({ listId, sortBy }: { listId: string; so
 
   return (
     <>
-      {data.map((item) => (
+      {filteredPlaces.map((item) => (
         <PlaceItem
           key={item.id}
           place={item}
           listId={listId}
           onClickItem={handleClickPlaceItem}
+          listTags={tags}
         />
       ))}
       {isOpenPlaceModal &&

--- a/components/features/place-list/tag/ColorPickerButton.tsx
+++ b/components/features/place-list/tag/ColorPickerButton.tsx
@@ -1,0 +1,64 @@
+import DropDown from '@/components/common/Dropdown';
+import { useDropdown } from '@/components/common/Dropdown/DropdownContext';
+import { TAG_COLORS, TAG_PALETTE, TagColor } from '@/lib/constants/tag';
+
+export default function ColorPickerButton({
+  value,
+  onChangeColor,
+}: {
+  value: TagColor;
+  onChangeColor: (color: TagColor) => void;
+}) {
+  return (
+    <DropDown
+      placement='bottom-start'
+      offsetValue={4}
+    >
+      <DropDown.Trigger className='rounded-lg border border-brand-gray-200 flex items-center justify-center p-2.5 box-border hover:bg-brand-gray-50'>
+        <span className={`rounded-full w-7 h-7 ${value ? TAG_PALETTE[value] : TAG_PALETTE['red']}`} />
+      </DropDown.Trigger>
+
+      <DropDown.Menu className='bg-white px-4 py-3 z-1100 rounded-lg shadow-md border border-brand-gray-200'>
+        <div
+          role='radiogroup'
+          aria-label='태그 색상 선택'
+          className='flex items-center gap-3'
+        >
+          {TAG_COLORS.map((color, index) => (
+            <ColorChip
+              key={index}
+              color={color}
+              selected={value === color}
+              onSelect={onChangeColor}
+            />
+          ))}
+        </div>
+      </DropDown.Menu>
+    </DropDown>
+  );
+}
+
+function ColorChip({
+  color,
+  selected,
+  onSelect,
+}: {
+  color: TagColor;
+  selected: boolean;
+  onSelect: (color: TagColor) => void;
+}) {
+  const { close } = useDropdown();
+  return (
+    <button
+      type='button'
+      value={color}
+      onClick={() => {
+        onSelect(color);
+        close();
+      }}
+      role='radio'
+      aria-checked={selected}
+      className={`rounded-full w-7 h-7 ${TAG_PALETTE[color]} cursor-pointer`}
+    />
+  );
+}

--- a/components/features/place-list/tag/PlaceTag.tsx
+++ b/components/features/place-list/tag/PlaceTag.tsx
@@ -1,36 +1,35 @@
 import { Icon } from '@/components/common/Icon';
+import { PLACE_TAG_COLOR } from '@/lib/constants/tag';
 import { Tag } from '@/types/placeList';
-
-// 단일 장소 아이템, 장소 리스트 관리 페이지 안 태그에 사용될 색상 태그 컴포넌트
-const colorVariant = {
-  red: 'text-tag-red-text bg-tag-red-fill border-tag-red-stroke',
-  hotpink: 'text-tag-hotpink-text bg-tag-hotpink-fill border-tag-hotpink-stroke',
-  blue: 'text-brand-blue-500 border-brand-blue-100 bg-brand-blue-50',
-  yellow: 'text-tag-yellow-text bg-tag-yellow-fill border-tag-yellow-stroke',
-  green: 'text-tag-green-text bg-tag-green-fill border-tag-green-stroke',
-  purple: 'text-tag-purple-text bg-tag-purple-fill border-tag-purple-stroke',
-  grey: 'text-brand-gray-500 bg-brand-gray-50 border-brand-gray-100',
-};
 
 interface PlaceTagProps {
   tag: Tag;
+  isEdit?: boolean;
+  isSelected?: boolean;
   onClick?: () => void;
   isRounded?: boolean;
 }
 
-export default function PlaceTag({ tag, onClick, isRounded = false }: PlaceTagProps) {
+export default function PlaceTag({ tag, onClick, isRounded = false, isEdit = false, isSelected }: PlaceTagProps) {
   return (
-    <div
-      className={`block shrink-0 text-typo-caption box-border ${isRounded ? 'rounded-[28px]' : 'rounded-sm'} border px-2 py-1 ${colorVariant[tag.color]}`}
+    <button
+      className={`shrink-0  flex gap-1 items-center justify-center box-border ${isRounded ? 'rounded-[28px]' : 'rounded-sm'} border ${isEdit && !isSelected ? 'border-brand-gray-300 text-brand-gray-500' : PLACE_TAG_COLOR[tag.color]} ${isEdit ? 'text-typo-description px-3 py-1.5' : 'text-typo-caption px-2 py-1'}`}
       onClick={onClick}
+      aria-pressed={isEdit ? isSelected : undefined}
     >
-      {onClick && (
-        <Icon
-          name='Check'
-          size={18}
-        />
-      )}
+      {isEdit &&
+        (isSelected ? (
+          <Icon
+            name='Check'
+            size={18}
+          />
+        ) : (
+          <Icon
+            name='Plus'
+            size={18}
+          />
+        ))}
       {tag.name}
-    </div>
+    </button>
   );
 }

--- a/components/features/place-list/tag/PlaceTag.tsx
+++ b/components/features/place-list/tag/PlaceTag.tsx
@@ -13,7 +13,7 @@ interface PlaceTagProps {
 export default function PlaceTag({ tag, onClick, isRounded = false, isEdit = false, isSelected }: PlaceTagProps) {
   return (
     <button
-      className={`shrink-0  flex gap-1 items-center justify-center box-border ${isRounded ? 'rounded-[28px]' : 'rounded-sm'} border ${isEdit && !isSelected ? 'border-brand-gray-300 text-brand-gray-500' : PLACE_TAG_COLOR[tag.color]} ${isEdit ? 'text-typo-description px-3 py-1.5' : 'text-typo-caption px-2 py-1'}`}
+      className={`shrink-0  flex gap-1 items-center justify-center box-border ${isRounded ? 'rounded-[28px]' : 'rounded-sm'} border ${isEdit && !isSelected ? 'border-brand-gray-300 text-brand-gray-500' : PLACE_TAG_COLOR[tag.color]} ${isEdit ? 'text-typo-description px-3 py-1.5' : 'text-typo-caption px-2 py-1'} hover:bg-brand-gray-50 cursor-pointer`}
       onClick={onClick}
       aria-pressed={isEdit ? isSelected : undefined}
     >

--- a/components/features/place-list/tag/TagList.tsx
+++ b/components/features/place-list/tag/TagList.tsx
@@ -1,23 +1,22 @@
 'use client';
 
-import { useState } from 'react';
-
 import { useGetPlaceListTags } from '@/hooks/place-list/useGetPlaceListTags';
 import { useDragScroll } from '@/hooks/useDragScroll';
 import { useModalStore } from '@/lib/store/modalStore';
 
 import TagListItem from './TagListItem';
 
+interface TagListProps {
+  listId: string;
+  activeTagIds: Set<string>;
+  onToggleTag: (id: string) => void;
+}
+
 // 장소 리스트에 포함된 태그를 보여주는 태그 리스트 컴포넌트(상단에 위치)
-export default function TagList({ listId }: { listId: string }) {
+export default function TagList({ listId, activeTagIds, onToggleTag }: TagListProps) {
   const { open } = useModalStore();
   const { data } = useGetPlaceListTags(listId);
   const { ref, ...dragHandler } = useDragScroll<HTMLDivElement>();
-  const [activeIds, setActiveIds] = useState<string[]>([]);
-
-  const handleToggleTag = (id: string) => {
-    setActiveIds((prev) => (prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id]));
-  };
 
   return (
     <div
@@ -29,8 +28,8 @@ export default function TagList({ listId }: { listId: string }) {
         <TagListItem
           key={item.id}
           tag={item}
-          isActivated={activeIds.includes(item.id)}
-          onClick={() => handleToggleTag(item.id)}
+          isActivated={activeTagIds.has(item.id)}
+          onClick={() => onToggleTag(item.id)}
         />
       ))}
       <button

--- a/components/features/place-list/tag/TagList.tsx
+++ b/components/features/place-list/tag/TagList.tsx
@@ -1,12 +1,16 @@
 'use client';
 
-import TagListItem from './TagListItem';
 import { useState } from 'react';
-import { useDragScroll } from '@/hooks/useDragScroll';
+
 import { useGetPlaceListTags } from '@/hooks/place-list/useGetPlaceListTags';
+import { useDragScroll } from '@/hooks/useDragScroll';
+import { useModalStore } from '@/lib/store/modalStore';
+
+import TagListItem from './TagListItem';
 
 // 장소 리스트에 포함된 태그를 보여주는 태그 리스트 컴포넌트(상단에 위치)
 export default function TagList({ listId }: { listId: string }) {
+  const { open } = useModalStore();
   const { data } = useGetPlaceListTags(listId);
   const { ref, ...dragHandler } = useDragScroll<HTMLDivElement>();
   const [activeIds, setActiveIds] = useState<string[]>([]);
@@ -29,7 +33,12 @@ export default function TagList({ listId }: { listId: string }) {
           onClick={() => handleToggleTag(item.id)}
         />
       ))}
-      <button className='px-3 py-1.75 text-brand-blue-700 shrink-0'>태그 수정</button>
+      <button
+        className='px-3 py-1.75 text-brand-blue-700 shrink-0 hover:bg-black/5 rounded-full cursor-pointer'
+        onClick={() => open({ type: 'tag', props: { listId } })}
+      >
+        태그 수정
+      </button>
     </div>
   );
 }

--- a/components/features/place-list/tag/TagListItem.tsx
+++ b/components/features/place-list/tag/TagListItem.tsx
@@ -14,6 +14,7 @@ export default function TagListItem({ tag, isActivated, onClick }: TagListItemPr
     <button
       className={`flex items-center justify-center shrink-0 box-border px-3 py-1.5 rounded-[40px] cursor-pointer border border-brand-blue-700 ${isActivated ? 'text-brand-gray-50 bg-brand-blue-700' : 'text-brand-blue-700'}`}
       onClick={onClick}
+      data-drag-item
     >
       {tag.name}
     </button>

--- a/components/features/place-list/tag/TagModal.tsx
+++ b/components/features/place-list/tag/TagModal.tsx
@@ -76,13 +76,7 @@ export default function TagModal({ listId }: { listId: string }) {
   };
 
   return (
-    <div
-      className='modal-overlay'
-      onClick={(e) => {
-        e.stopPropagation();
-        close();
-      }}
-    >
+    <>
       <div
         className='relative flex flex-col bg-white rounded-lg min-h-100 h-187 max-h-[80vh] min-w-126 overflow-hidden pt-7 px-6'
         onClick={(e) => e.stopPropagation()}
@@ -147,6 +141,6 @@ export default function TagModal({ listId }: { listId: string }) {
           </button>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/components/features/place-list/tag/TagModal.tsx
+++ b/components/features/place-list/tag/TagModal.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+
+import EmptyState from '@/components/common/EmptyState';
+import { Icon } from '@/components/common/Icon';
+import { useGetPlaceListTags } from '@/hooks/place-list/useGetPlaceListTags';
+import { useUpdateTags } from '@/hooks/place-list/useUpdateTags';
+import { TagColor } from '@/lib/constants/tag';
+import { useModalStore } from '@/lib/store/modalStore';
+import { getErrorMessage, RpcError, RpcErrorMessage } from '@/types/errors';
+import { TagRowParams } from '@/types/placeList';
+
+import TagRow from './TagRow';
+
+export default function TagModal({ listId }: { listId: string }) {
+  const { close } = useModalStore();
+  const { data: existingTags } = useGetPlaceListTags(listId);
+  const [newTag, setNewTag] = useState<TagRowParams[]>(() =>
+    existingTags.map((tag) => ({
+      key: crypto.randomUUID(),
+      id: tag.id,
+      name: tag.name,
+      color: tag.color,
+    })),
+  );
+  const { mutateAsync: updateTags, isPending } = useUpdateTags();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAddRow = () => {
+    setNewTag((prev) => [...prev, { key: crypto.randomUUID(), name: '', color: 'red' }]);
+  };
+
+  const handleDeleteRow = (key: string) => {
+    setNewTag((prev) => prev.filter((tag) => tag.key !== key));
+  };
+
+  const handleChangeName = (key: string, e: React.ChangeEvent<HTMLInputElement>) => {
+    setNewTag((prev) => prev.map((tag) => (tag.key === key ? { ...tag, name: e.target.value } : tag)));
+  };
+
+  const handleChangeColor = (key: string, color: TagColor) => {
+    setNewTag((prev) => prev.map((tag) => (tag.key === key ? { ...tag, color } : tag)));
+  };
+
+  const handleSubmit = async () => {
+    if (newTag.length === 0) return;
+    if (newTag.some((tag) => !tag.name.trim())) {
+      setError('태그명을 입력해주세요.');
+      return;
+    }
+
+    try {
+      setError(null);
+      await updateTags(
+        { listId, tags: newTag },
+        {
+          onSuccess: (result) => {
+            setNewTag(
+              result.data.map((tag) => ({
+                key: crypto.randomUUID(),
+                id: tag.id,
+                name: tag.name,
+                color: tag.color,
+              })),
+            );
+          },
+        },
+      );
+    } catch (error) {
+      const message =
+        error instanceof RpcError
+          ? getErrorMessage(error.message as RpcErrorMessage, { subject: '태그', action: '편집' })
+          : getErrorMessage('INTERNAL_ERROR', { subject: '태그', action: '편집' });
+
+      setError(message);
+    }
+  };
+
+  return (
+    <div
+      className='modal-overlay'
+      onClick={(e) => {
+        e.stopPropagation();
+        close();
+      }}
+    >
+      <div
+        className='relative flex flex-col bg-white rounded-lg min-h-100 h-187 max-h-[80vh] min-w-126 overflow-hidden pt-7 px-6'
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className='flex items-center justify-between'>
+          <span className='text-typo-title text-brand-blue-800'>태그 관리</span>
+          <button
+            onClick={close}
+            className='text-brand-gray-500 rounded-full cursor-pointer hover:bg-brand-gray-100 hover:text-brand-blue-700'
+          >
+            <Icon
+              name='XClose'
+              size={32}
+            />
+          </button>
+        </header>
+
+        <button
+          className='w-full flex items-center justify-center gap-2.5 border border-brand-blue-700 text-brand-blue-700 px-3 py-2 rounded-lg cursor-pointer hover:bg-brand-blue-700 hover:text-brand-gray-0 text-typo-base mt-7 mb-3'
+          onClick={handleAddRow}
+        >
+          <Icon
+            name='Plus'
+            size={24}
+          />
+          태그 추가
+        </button>
+
+        <div className='flex flex-col gap-2 min-h-0 overflow-y-auto flex-1 -mx-6 px-6 pb-26'>
+          {newTag.length > 0 ? (
+            newTag.map((tag) => (
+              <TagRow
+                key={tag.key}
+                name={tag.name}
+                color={tag.color}
+                onDelete={() => handleDeleteRow(tag.key)}
+                onChangeColor={(color) => handleChangeColor(tag.key, color)}
+                onChangeName={(e) => handleChangeName(tag.key, e)}
+              />
+            ))
+          ) : (
+            <EmptyState message='생성한 태그가 아직 없습니다.' />
+          )}
+        </div>
+
+        <div className='absolute left-0 bottom-0 w-full px-6 py-5 bg-brand-gray-200 rounded-b-lg flex flex-row justify-end gap-3'>
+          {error && (
+            <span
+              role='alert'
+              className='text-red-500 text-typo-description text-right'
+            >
+              {error}
+            </span>
+          )}
+          <button
+            className='float-right py-3 px-9 typo-text-base-bold text-white bg-brand-blue-700 rounded-sm hover:bg-brand-blue-800 cursor-pointer'
+            form='UpdatePlanInfoForm'
+            type='button'
+            onClick={handleSubmit}
+          >
+            {isPending ? '저장 중...' : '저장하기'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/features/place-list/tag/TagRow.tsx
+++ b/components/features/place-list/tag/TagRow.tsx
@@ -1,0 +1,42 @@
+import { Icon } from '@/components/common/Icon';
+import { TagColor } from '@/lib/constants/tag';
+
+import ColorPickerButton from './ColorPickerButton';
+
+interface TagRowProps {
+  color: TagColor;
+  name: string;
+  onDelete: () => void;
+  onChangeName: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChangeColor: (color: TagColor) => void;
+}
+
+export default function TagRow({ color, name, onChangeName, onDelete, onChangeColor }: TagRowProps) {
+  return (
+    <div className='flex items-center gap-2'>
+      <ColorPickerButton
+        value={color}
+        onChangeColor={onChangeColor}
+      />
+
+      <div className='flex-1 relative'>
+        <input
+          type='text'
+          className='items-center box-border w-full border-transparent rounded-lg px-3 h-12 bg-brand-gray-100 border focus:outline-none focus:bg-brand-gray-0 focus:border-brand-blue-400 hover:bg-brand-gray-200 text-brand-gray-700 placeholder-brand-gray-400'
+          value={name}
+          onChange={onChangeName}
+          placeholder='태그명'
+        />
+        <button
+          onClick={onDelete}
+          className='absolute right-3 top-3 text-brand-gray-500 cursor-pointer hover:text-brand-blue-800'
+        >
+          <Icon
+            name='XClose'
+            size={24}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/features/plan/PlanSettingModal.tsx
+++ b/components/features/plan/PlanSettingModal.tsx
@@ -6,18 +6,21 @@ import Loader from '@/components/common/Loader';
 import ShareOptionContent from '@/components/common/ShareOption/ShareOptionContent';
 import TabButton from '@/components/common/TabButton';
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
+import { useModalControl } from '@/hooks/useModalControl';
 
 import PlanInfoContent from './plan-info/PlanInfoContent';
 
 export default function PlanSettingModal({ id, onClose }: { id: string; onClose: () => void }) {
   const [tab, setTab] = useState<'info' | 'shareOption'>('info');
+  const { handleMouseDown, handleMouseUp } = useModalControl(onClose);
 
   return createPortal(
     <div
       className='modal-overlay'
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
       onClick={(e) => {
         e.stopPropagation();
-        onClose();
       }}
     >
       <div

--- a/components/features/plan/plan-info/FormTypeSelectDeparture.tsx
+++ b/components/features/plan/plan-info/FormTypeSelectDeparture.tsx
@@ -180,7 +180,7 @@ export default function FormTypeSelectDeparture({
                           >
                             {option.label}
                             {option.value === value && (
-                              <span className='absolute inset-y-0 right-0 flex items-center pr-4'>
+                              <span className='absolute inset-y-0 right-0 flex items-center pr-4 text-brand-blue-500'>
                                 <Icon
                                   name='Check'
                                   size={16}

--- a/hooks/place-list/useDeletePlace.ts
+++ b/hooks/place-list/useDeletePlace.ts
@@ -1,7 +1,10 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { deletePlace } from '@/lib/actions/placeList';
 import { useModalStore } from '@/lib/store/modalStore';
 import { getErrorMessage, RpcError, RpcErrorMessage } from '@/types/errors';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { placeListDetailQueryOptions } from './useGetPlaceListDetail';
 
 export const useDeletePlace = (listId: string) => {
   const queryClient = useQueryClient();
@@ -22,6 +25,7 @@ export const useDeletePlace = (listId: string) => {
       queryClient.invalidateQueries({
         queryKey: ['place-list', listId, 'places'],
       });
+      queryClient.invalidateQueries({ queryKey: placeListDetailQueryOptions(listId).queryKey });
     },
     onError: (error) => {
       console.error('❌ 단일 장소 삭제 실패');

--- a/hooks/place-list/useGetPlaceListTags.ts
+++ b/hooks/place-list/useGetPlaceListTags.ts
@@ -1,6 +1,7 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+
 import { RpcError, RpcErrorMessage, RpcErrorResponseBody } from '@/types/errors';
 import { Tag } from '@/types/placeList';
-import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
 
 const fetchPlaceListTags = async (listId: string): Promise<Tag[]> => {
   const res = await fetch(`/api/view/place-list/${listId}/tags`);

--- a/hooks/place-list/useUpdatePlace.ts
+++ b/hooks/place-list/useUpdatePlace.ts
@@ -1,8 +1,10 @@
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { placeListTagsQueryOptions } from '@/hooks/place-list/useGetPlaceListTags';
 import { updatePlace } from '@/lib/actions/placeList';
 import { useModalStore } from '@/lib/store/modalStore';
 import { getErrorMessage, RpcError, RpcErrorMessage } from '@/types/errors';
 import { Place } from '@/types/placeList';
-import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdatePlace = (listId: string) => {
   const queryClient = useQueryClient();
@@ -10,8 +12,8 @@ export const useUpdatePlace = (listId: string) => {
   const { open } = useModalStore();
 
   return useMutation({
-    mutationFn: async ({ placeId, memo }: { placeId: string; memo: string | null }) => {
-      const result = await updatePlace({ listId, placeId, memo });
+    mutationFn: async ({ placeId, memo, tags }: { placeId: string; memo: string | null; tags: string[] }) => {
+      const result = await updatePlace({ listId, placeId, memo, tags });
 
       if (!result.success) {
         throw new RpcError(result.error.message, result.error.code);
@@ -20,6 +22,13 @@ export const useUpdatePlace = (listId: string) => {
       return result;
     },
     onSuccess: (_, variables) => {
+      // 화면에 태그를 완전히 그리기 위해 리스트 태그 캐시에서 id로 역참조
+      const listTags = queryClient.getQueryData(placeListTagsQueryOptions(listId).queryKey) ?? [];
+      const tagMap = new Map(listTags.map((tag) => [tag.id, tag]));
+
+      // 삭제된 태그가 섞여 있을 경우를 대비해 undefined 필터링
+      const resolvedTags = variables.tags.map((id) => tagMap.get(id)).filter((tag) => tag !== undefined);
+
       queryClient.setQueriesData(
         { queryKey: ['place-list', listId, 'places', 'list'] },
         (old: InfiniteData<Place[]> | undefined) => {
@@ -27,7 +36,9 @@ export const useUpdatePlace = (listId: string) => {
           return {
             ...old,
             pages: old.pages.map((page) =>
-              page.map((p) => (p.id === variables.placeId ? { ...p, memoContent: variables.memo } : p)),
+              page.map((p) =>
+                p.id === variables.placeId ? { ...p, memoContent: variables.memo, tags: resolvedTags } : p,
+              ),
             ),
           };
         },

--- a/hooks/place-list/useUpdatePlace.ts
+++ b/hooks/place-list/useUpdatePlace.ts
@@ -24,10 +24,10 @@ export const useUpdatePlace = (listId: string) => {
     onSuccess: (_, variables) => {
       // 화면에 태그를 완전히 그리기 위해 리스트 태그 캐시에서 id로 역참조
       const listTags = queryClient.getQueryData(placeListTagsQueryOptions(listId).queryKey) ?? [];
-      const tagMap = new Map(listTags.map((tag) => [tag.id, tag]));
+      const selectedIds = new Set(variables.tags);
 
-      // 삭제된 태그가 섞여 있을 경우를 대비해 undefined 필터링
-      const resolvedTags = variables.tags.map((id) => tagMap.get(id)).filter((tag) => tag !== undefined);
+      // 이미 order로 정렬된 리스트 태그 기준으로 선택된 것만 필터링
+      const resolvedTags = listTags.filter((tag) => selectedIds.has(tag.id));
 
       queryClient.setQueriesData(
         { queryKey: ['place-list', listId, 'places', 'list'] },

--- a/hooks/place-list/useUpdateTags.ts
+++ b/hooks/place-list/useUpdateTags.ts
@@ -1,8 +1,8 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { updateTags } from '@/lib/actions/placeList';
 import { RpcError } from '@/types/errors';
-import { TagRowParams } from '@/types/placeList';
+import { Place, TagRowParams } from '@/types/placeList';
 
 import { placeListTagsQueryOptions } from './useGetPlaceListTags';
 
@@ -21,6 +21,27 @@ export const useUpdateTags = () => {
     },
     onSuccess: (result, variables) => {
       queryClient.setQueryData(placeListTagsQueryOptions(variables.listId).queryKey, result.data);
+
+      // 태그 삭제 및 수정 시 단일 장소 컴포넌트에 즉시 반영하기 위해 Map 선언
+      const tagMap = new Map(result.data.map((tag) => [tag.id, tag]));
+
+      queryClient.setQueriesData(
+        {
+          queryKey: ['place-list', variables.listId, 'places', 'list'],
+        },
+        (old: InfiniteData<Place[]> | undefined) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page) =>
+              page.map((place) => ({
+                ...place,
+                tags: place.tags.map((tag) => tagMap.get(tag.id)).filter((tag) => tag !== undefined),
+              })),
+            ),
+          };
+        },
+      );
     },
     onError: (error) => {
       console.error('❌ 태그 편집 실패', error);

--- a/hooks/place-list/useUpdateTags.ts
+++ b/hooks/place-list/useUpdateTags.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateTags } from '@/lib/actions/placeList';
+import { RpcError } from '@/types/errors';
+import { TagRowParams } from '@/types/placeList';
+
+import { placeListTagsQueryOptions } from './useGetPlaceListTags';
+
+export const useUpdateTags = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId, tags }: { listId: string; tags: TagRowParams[] }) => {
+      const result = await updateTags({ listId, tags });
+
+      if (!result.success) {
+        throw new RpcError(result.error.message, result.error.code);
+      }
+
+      return result;
+    },
+    onSuccess: (result, variables) => {
+      queryClient.setQueryData(placeListTagsQueryOptions(variables.listId).queryKey, result.data);
+    },
+    onError: (error) => {
+      console.error('❌ 태그 편집 실패', error);
+    },
+  });
+};

--- a/hooks/useDragScroll.ts
+++ b/hooks/useDragScroll.ts
@@ -53,6 +53,11 @@ export const useDragScroll = <T extends HTMLElement>() => {
       const target = e.target as HTMLElement;
       if (target.closest('[data-vertical-scroll]')) return; // 안에서는 원래 세로 스크롤 그대로 둠
 
+      // 맥 좌우 스와이프 유지
+      if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+        return;
+      }
+
       if (e.deltaY !== 0) {
         e.preventDefault();
         // 휠 세로 이동량 계산 - 휠 내리면 오른쪽 스크롤, 휠 올리면 왼쪽 스크롤

--- a/hooks/useDragScroll.ts
+++ b/hooks/useDragScroll.ts
@@ -52,9 +52,12 @@ export const useDragScroll = <T extends HTMLElement>() => {
     const handleWheel = (e: WheelEvent) => {
       const target = e.target as HTMLElement;
       if (target.closest('[data-vertical-scroll]')) return; // 안에서는 원래 세로 스크롤 그대로 둠
-      e.preventDefault();
-      // 휠 세로 이동량 계산 - 휠 내리면 오른쪽 스크롤, 휠 올리면 왼쪽 스크롤
-      el.scrollLeft += e.deltaY;
+
+      if (e.deltaY !== 0) {
+        e.preventDefault();
+        // 휠 세로 이동량 계산 - 휠 내리면 오른쪽 스크롤, 휠 올리면 왼쪽 스크롤
+        el.scrollLeft += e.deltaY;
+      }
     };
 
     el.addEventListener('mousemove', handleMouseMove, { passive: false });
@@ -67,8 +70,8 @@ export const useDragScroll = <T extends HTMLElement>() => {
   }, []);
 
   const onClick = useCallback((e: React.MouseEvent) => {
-    // 5px 이상 움직였다면(드래그중이면) 클릭 무시
-    if (Math.abs(moveX.current) > 5) {
+    // 8px 이상 움직였다면(드래그중이면) 클릭 무시
+    if (Math.abs(moveX.current) > 8) {
       e.stopPropagation();
     }
   }, []);

--- a/hooks/useModalControl.ts
+++ b/hooks/useModalControl.ts
@@ -1,9 +1,6 @@
 import { useRef } from 'react';
 
-import { useModalStore } from '@/lib/store/modalStore';
-
-export const useModalControl = () => {
-  const { close } = useModalStore();
+export const useModalControl = (onClose: () => void) => {
   const isClickOverlay = useRef<boolean>(false);
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -12,7 +9,7 @@ export const useModalControl = () => {
 
   const handleMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
     if (isClickOverlay.current && e.target === e.currentTarget) {
-      close();
+      onClose();
     }
     isClickOverlay.current = false;
   };

--- a/hooks/useModalControl.ts
+++ b/hooks/useModalControl.ts
@@ -1,0 +1,25 @@
+import { useRef } from 'react';
+
+import { useModalStore } from '@/lib/store/modalStore';
+
+export const useModalControl = () => {
+  const { close } = useModalStore();
+  const isClickOverlay = useRef<boolean>(false);
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    isClickOverlay.current = e.target === e.currentTarget;
+  };
+
+  const handleMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (isClickOverlay.current && e.target === e.currentTarget) {
+      close();
+    }
+    isClickOverlay.current = false;
+  };
+
+  return {
+    isClickOverlay,
+    handleMouseDown,
+    handleMouseUp,
+  };
+};

--- a/lib/actions/api/prefetch/prefetchPlaceListDetail.ts
+++ b/lib/actions/api/prefetch/prefetchPlaceListDetail.ts
@@ -1,10 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { QueryClient } from '@tanstack/react-query';
+
+import { placeListPlacesQueryOptions } from '@/hooks/place-list/useGetPlaceListPlaces';
+import { placeListPlacesCoordinateQueryOptions } from '@/hooks/place-list/useGetPlaceListPlacesCoordinate';
+import { placeListTagsQueryOptions } from '@/hooks/place-list/useGetPlaceListTags';
 import { getPlaceListPlaces, getPlaceListPlacesCoordinate, getPlaceListTags } from '@/lib/actions/api/placeList';
 import type { PageParam } from '@/types/placeList';
-import { placeListPlacesQueryOptions } from '@/hooks/place-list/useGetPlaceListPlaces';
-import { placeListTagsQueryOptions } from '@/hooks/place-list/useGetPlaceListTags';
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { placeListPlacesCoordinateQueryOptions } from '@/hooks/place-list/useGetPlaceListPlacesCoordinate';
 
 export async function prefetchPlaceListDetail(queryClient: QueryClient, listId: string, supabase: SupabaseClient) {
   await Promise.all([
@@ -19,10 +20,9 @@ export async function prefetchPlaceListDetail(queryClient: QueryClient, listId: 
       ...placeListPlacesCoordinateQueryOptions(listId),
       queryFn: () => getPlaceListPlacesCoordinate({ supabase, listId }),
     }),
-    // TODO: 2차에 태그 기능 추가
-    // queryClient.prefetchQuery({
-    //   ...placeListTagsQueryOptions(listId),
-    //   queryFn: () => getPlaceListTags({ supabase, listId }),
-    // }),
+    queryClient.prefetchQuery({
+      ...placeListTagsQueryOptions(listId),
+      queryFn: () => getPlaceListTags({ supabase, listId }),
+    }),
   ]);
 }

--- a/lib/actions/placeList.ts
+++ b/lib/actions/placeList.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { ActionResult, isPostgresError, RpcErrorMessage, SQLSTATE_TO_RPC_ERROR } from '@/types/errors';
-import { UpdatePlaceListParams, UpdatePlaceParams } from '@/types/placeList';
+import { Tag, TagRowParams, UpdatePlaceListParams, UpdatePlaceParams } from '@/types/placeList';
 
 import { auth } from '../utils/auth';
 import { supabaseAdmin, supabaseUser } from '../utils/supabase';
@@ -136,6 +136,36 @@ export const updatePlaceList = async ({ params }: { params: UpdatePlaceListParam
     return { success: true, data: null };
   } catch (error: unknown) {
     console.error('❌ 장소 리스트 편집 실패: ', error);
+    const code = isPostgresError(error) ? error.code : undefined;
+    const message = ((code && SQLSTATE_TO_RPC_ERROR[code]) ?? 'INTERNAL_ERROR') as RpcErrorMessage;
+    return { success: false, error: { message, code } };
+  }
+};
+
+// 태그 편집(생성, 수정, 삭제)
+export const updateTags = async ({
+  listId,
+  tags,
+}: {
+  listId: string;
+  tags: TagRowParams[];
+}): Promise<ActionResult<Tag[]>> => {
+  try {
+    const supabase = await supabaseUser();
+    const { error, data } = await supabase.rpc('update_tags', {
+      p_list_id: listId,
+      p_tags: tags,
+    });
+
+    if (error) {
+      console.error('❌ 태그 편집 실패: ', error);
+      const message = SQLSTATE_TO_RPC_ERROR[error.code] ?? 'INTERNAL_ERROR';
+      return { success: false, error: { message, code: error.code } };
+    }
+
+    return { success: true, data };
+  } catch (error: unknown) {
+    console.error('❌ 태그 편집 실패: ', error);
     const code = isPostgresError(error) ? error.code : undefined;
     const message = ((code && SQLSTATE_TO_RPC_ERROR[code]) ?? 'INTERNAL_ERROR') as RpcErrorMessage;
     return { success: false, error: { message, code } };

--- a/lib/actions/placeList.ts
+++ b/lib/actions/placeList.ts
@@ -91,13 +91,14 @@ export const deletePlace = async ({
 };
 
 // 단일 장소 편집
-export const updatePlace = async ({ listId, placeId, memo }: UpdatePlaceParams): Promise<ActionResult<null>> => {
+export const updatePlace = async ({ listId, placeId, memo, tags }: UpdatePlaceParams): Promise<ActionResult<null>> => {
   try {
     const supabase = await supabaseUser();
     const { error } = await supabase.rpc('update_place', {
       p_list_id: listId,
       p_place_id: placeId,
       p_memo: memo,
+      p_tag_ids: tags,
     });
 
     if (error) {

--- a/lib/constants/tag.ts
+++ b/lib/constants/tag.ts
@@ -1,0 +1,25 @@
+export const TAG_COLORS = ['hotpink', 'red', 'yellow', 'green', 'blue', 'purple', 'grey'] as const;
+
+export type TagColor = (typeof TAG_COLORS)[number];
+
+// 태그 관리 모달에서 사용할 팔레트 색상
+export const TAG_PALETTE: Record<TagColor, string> = {
+  red: 'bg-tag-red-stroke',
+  hotpink: 'bg-tag-hotpink-stroke',
+  blue: 'bg-brand-blue-100',
+  yellow: 'bg-tag-yellow-stroke',
+  green: 'bg-tag-green-stroke',
+  purple: 'bg-tag-purple-stroke',
+  grey: 'bg-brand-gray-300',
+};
+
+// 단일 장소 컴포넌트에 사용할 태그 색상
+export const PLACE_TAG_COLOR: Record<TagColor, string> = {
+  red: 'text-tag-red-text bg-tag-red-fill border-tag-red-stroke',
+  hotpink: 'text-tag-hotpink-text bg-tag-hotpink-fill border-tag-hotpink-stroke',
+  blue: 'text-brand-blue-500 border-brand-blue-100 bg-brand-blue-50',
+  yellow: 'text-tag-yellow-text bg-tag-yellow-fill border-tag-yellow-stroke',
+  green: 'text-tag-green-text bg-tag-green-fill border-tag-green-stroke',
+  purple: 'text-tag-purple-text bg-tag-purple-fill border-tag-purple-stroke',
+  grey: 'text-brand-gray-500 bg-brand-gray-50 border-brand-gray-100',
+};

--- a/lib/store/modalStore.ts
+++ b/lib/store/modalStore.ts
@@ -26,6 +26,10 @@ type ModalPayload =
   | {
       type: 'deletePlanDate';
       props: { onConfirm: () => void; dayNumber: number; type: 'deleteDayPlan' | 'deleteAllPlanItems' };
+    }
+  | {
+      type: 'tag';
+      props: { listId: string };
     };
 
 interface ModalState {

--- a/types/placeList.ts
+++ b/types/placeList.ts
@@ -90,7 +90,7 @@ export interface UpdatePlaceParams {
   listId: string;
   placeId: string;
   memo: string | null;
-  //  tags: Tag[]
+  tags: string[];
 }
 
 // 저장된 장소 호출 파라미터

--- a/types/placeList.ts
+++ b/types/placeList.ts
@@ -1,9 +1,10 @@
+import { TagColor } from '@/lib/constants/tag';
+
 import { PlaceCategory } from './corePlace';
 import { Role } from './shareOption';
 
 //장소 리스트 유형 - 공유된, 저장된 리스트로 구분해서 볼 때 사용
 export type ListType = 'all' | 'owned' | 'shared';
-export type TagColor = 'red' | 'hotpink' | 'yellow' | 'green' | 'blue' | 'purple' | 'grey';
 
 // 저장된 장소 정렬 타입 - 최근 등록순, 과거 등록순, 최근 수정순
 export type SortType = 'created_desc' | 'created_asc';
@@ -17,6 +18,14 @@ export type PageParam = {
 // 장소 태그
 export interface Tag {
   id: string;
+  name: string;
+  color: TagColor;
+}
+
+// 태그 편집 파라미터
+export interface TagRowParams {
+  key: string;
+  id?: string;
   name: string;
   color: TagColor;
 }


### PR DESCRIPTION
## 🛠️ 과제 요약

- 태그 관리 모달 구현
- 장소 리스트 페이지 태그 기능 추가: 조회, 태그 필터링, 장소 컴포넌트 단일편집 시 태그 추가
- 전역 모달 마우스 이벤트 조정
- 가로 스크롤 훅 마우스 휠 이벤트 조정

## 📝 요구 사항과 구현 내용

#### 1️⃣ 태그 관리 모달 구현
<img width="600" alt="스크린샷 2026-09-06 오전 12 26 22" src="https://github.com/user-attachments/assets/ada10c89-07f2-44c0-9761-293e4f844c68" /><br/>
- update_tags rpc 생성: 태그는 해당 모달에서 일괄적으로 생성, 수정, 삭제되므로 하나의 rpc로 구현
  - 새로 생성되는 태그는 id가 없어서, 식별을 위한 임시 key 값을 클라이언트 로컬 상태에서만 별도로 관리
- 색상 선택 팔레트는 드롭다운을 사용해서 구현(`ColorPickerButton`)했는데, 팔레트의 자체 스타일이 필요해서 드롭다운의 `Menu.tsx`에 className prop을 추가

#### 2️⃣ 장소 리스트 페이지 태그 기능 추가
- 리스트에 포함된 태그 조회 
- 태그 클릭 시 해당하는 장소 필터링
  - 태그가 많아질 가능성이 혹시라도 있으니 태그 id 배열 상태를 Set으로 선언해 조회 시간 단축
  - AND 식으로 할지 OR 식으로 할지 고민하다가 일단 더 많은 장소가 보이도록 OR 방식으로 구현했습니다. 정확도가 더 중요하다 싶으면 다시 AND 방식으로 변경하겠습니다! 
- 단일 장소 컴포넌트에 태그 추가
<img width="367" height="115" alt="스크린샷 2026-09-06 오전 12 48 17" src="https://github.com/user-attachments/assets/f62ba9db-c238-4d7b-8970-f0de1c06c272" />
<img width="367" height="220" alt="스크린샷 2026-09-06 오전 12 48 33" src="https://github.com/user-attachments/assets/bf2b8c2d-d535-4e75-9886-293520bf045e" /><br/>
  - 읽기 모드, 편집 모드일 때 태그 조회, 수정이 가능하도록 수정
  - update_place rpc에 태그 수정 기능 추가: 태그 수정 시 추가 및 삭제하려는 태그의 id 배열을 받아서 수정
  - 단일 장소 편집(`updatePlace`)는 성공 여부만 반환하고, place_tag 테이블은 id만 저장하는 조인 테이블이라 태그의 이름과 색상 정보가 없으므로, useUpdatePlace에서 리스트 태그 캐시를 조회해 id를 실제 태그 객체로 매핑한 뒤 최종 상태에 반영

#### 3️⃣ 모달 컨트롤 훅 생성(`useModalControl.ts`)
- 가끔 모달 내부에서 시작한 mouseDown이 모달 외부에서 mouseUp되면 모달이 꺼지는 게 넘 불편해서 추가했습니다
- 전역 모달을 사용하지 않는 모달에서도 사용 가능하게끔 onClose를 주입받는 훅으로 구현했고, 일단 `GlobalModal`, `PlaceListShareOptionModal`,` PlanSettingModal`에만 적용해 두었습니다. 필요한 곳이 더 보이면 차차 적용하겠습니다

#### 4️⃣ 가로 스크롤 훅 마우스 휠 이벤트 조정(`useDragScroll`)
- 태그 목록 가로 스크롤 시 맥의 네이티브 좌우 스와이프가 막혀버려서 영향이 안 가게끔 조정했습니다
- 더불어 grab 드래그 시에 아이템이 너무 잘 눌리는 것 같아 8px로 살짝 올렸습니다

#### 5️⃣ check 아이콘 색상을 currentColor로 변경함에 따라 관련 컴포넌트에 명시적 색상 지정
#### 5️⃣ 장소 삭제 시 리스트 헤더 장소 개수에 바로 반영되게 쿼리 무효화(`useDeletePlace`)

## 💬 PR 포인트 & 궁금한 점
  - 태그 저장 시 간헐적으로 row 추가 순서가 보장되지 않는 경우가 있는데, 이는 저장 시 created_at이 같은 시간으로 설정되기 때문으로, id를 2차 정렬 기준으로 설정했지만 order가 보장되지 않는 상태입니다...! UX적으로 아쉽다면 order도 추가하겠습니다 말씀해주세용,,

## 🔗 연관된 이슈
- close #157 
- close #158 
- close #159 
- #160 
