### PR TITLE
[Feat/160] 리스트 전체 편집에 태그 수정 및 태그 필터링 기능 추가

### DIFF
--- a/app/(lobby)/places/(without-pattern)/[listId]/edit/page.tsx
+++ b/app/(lobby)/places/(without-pattern)/[listId]/edit/page.tsx
@@ -1,6 +1,7 @@
 import PlaceListEditForm from '@/components/features/place-list/edit/PlaceListEditForm';
 import { placeListDetailQueryOptions } from '@/hooks/place-list/useGetPlaceListDetail';
-import { getPlaceListDetail, getPlaceListPlaces } from '@/lib/actions/api/placeList';
+import { placeListTagsQueryOptions } from '@/hooks/place-list/useGetPlaceListTags';
+import { getPlaceListDetail, getPlaceListPlaces, getPlaceListTags } from '@/lib/actions/api/placeList';
 import { findEmoji } from '@/lib/emoji';
 import { getQueryClient } from '@/lib/utils/getQueryClient';
 import { supabaseUser } from '@/lib/utils/supabase';
@@ -28,11 +29,10 @@ export default async function PlaceListDetail({ params }: { params: Promise<{ li
           limit: null,
         }),
     }),
-    // TODO: 2차 추가
-    // queryClient.fetchQuery({
-    //   ...placeListTagsQueryOptions(listId),
-    //   queryFn: () => getPlaceListTags({supabase, listId})
-    // })
+    queryClient.fetchQuery({
+      ...placeListTagsQueryOptions(listId),
+      queryFn: () => getPlaceListTags({ supabase, listId }),
+    }),
   ]);
 
   const initialIcon = await findEmoji(detail.icon);
@@ -40,7 +40,7 @@ export default async function PlaceListDetail({ params }: { params: Promise<{ li
     id: p.id,
     customName: p.customName,
     memoContent: p.memoContent,
-    // tags: p.tags
+    tags: p.tags,
   }));
 
   return (

--- a/app/(lobby)/places/(without-pattern)/[listId]/edit/page.tsx
+++ b/app/(lobby)/places/(without-pattern)/[listId]/edit/page.tsx
@@ -40,7 +40,7 @@ export default async function PlaceListDetail({ params }: { params: Promise<{ li
     id: p.id,
     customName: p.customName,
     memoContent: p.memoContent,
-    tags: p.tags,
+    tagIds: p.tags.map((tag) => tag.id),
   }));
 
   return (

--- a/components/common/EmptyState.tsx
+++ b/components/common/EmptyState.tsx
@@ -1,3 +1,3 @@
 export default function EmptyState({ message }: { message: string }) {
-  return <div className='w-full font-light text-center py-7 text-brand-gray-400 text-typo-base'>{message}</div>;
+  return <div className='w-full font-light text-center py-10 text-brand-gray-400 text-typo-base'>{message}</div>;
 }

--- a/components/features/place-list/EditableOverviewField.tsx
+++ b/components/features/place-list/EditableOverviewField.tsx
@@ -91,20 +91,36 @@ export default function EditableOverviewField({
                 <span className='flex-1 min-w-0 text-start text-ellipsis overflow-hidden whitespace-nowrap'>
                   {icon ? icon.name : '아이콘 선택'}
                 </span>
-                <Icon
-                  name='ChevronDown'
-                  size={24}
-                />
+                <div className='flex items-center gap-2.5'>
+                  {icon && (
+                    <button
+                      type='button'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onSelectIcon(null);
+                      }}
+                      className='rounded-full cursor-pointer text-brand-gray-400 bg-[#DBDDE3] hover:text-brand-gray-700 flex items-center justify-center size-6'
+                    >
+                      <Icon
+                        name='XClose'
+                        size={24}
+                        strokeWidth={2}
+                      />
+                    </button>
+                  )}
+                  {!isOpenIconMenu ? (
+                    <Icon
+                      name='ChevronDown'
+                      size={24}
+                    />
+                  ) : (
+                    <Icon
+                      name='ChevronUp'
+                      size={24}
+                    />
+                  )}
+                </div>
               </button>
-              {icon && (
-                <button
-                  type='button'
-                  onClick={() => onSelectIcon(null)}
-                  className='bg-tag-red-text text-brand-gray-0 rounded-sm px-2 w-14 cursor-pointer font-light hover:bg-[#da4b46]'
-                >
-                  제거
-                </button>
-              )}
             </div>
 
             {isOpenIconMenu && (

--- a/components/features/place-list/EditableOverviewField.tsx
+++ b/components/features/place-list/EditableOverviewField.tsx
@@ -70,13 +70,20 @@ export default function EditableOverviewField({
 
           <div className='flex flex-col gap-2'>
             <div className='flex gap-1.5 w-full'>
-              <button
-                type='button'
+              <div
+                role='button'
+                tabIndex={0}
                 aria-labelledby='icon-label'
                 aria-haspopup='true'
                 aria-expanded={isOpenIconMenu}
                 onClick={() => setIsOpenIconMenu(!isOpenIconMenu)}
                 className={`flex-1 min-w-0 flex items-center box-border w-full rounded-sm px-3 py-2 bg-brand-gray-100 border focus-within:outline-2 focus-within:-outline-offset-2 focus:bg-brand-gray-0 focus-within:outline-indigo-600 border-brand-gray-200 shadow-xs hover:bg-brand-gray-200 placeholder-brand-gray-400 gap-2.5 cursor-pointer ${icon ? 'text-brand-gray-700' : 'text-brand-gray-400'}`}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setIsOpenIconMenu(!isOpenIconMenu);
+                  }
+                }}
               >
                 <span className='font-mona12 text-typo-base'>
                   {icon ? (
@@ -120,7 +127,7 @@ export default function EditableOverviewField({
                     />
                   )}
                 </div>
-              </button>
+              </div>
             </div>
 
             {isOpenIconMenu && (

--- a/components/features/place-list/detail/PlaceListDetailWrapper.tsx
+++ b/components/features/place-list/detail/PlaceListDetailWrapper.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 
 import { QueryBoundary } from '@/components/common/ui/boundary/Queryboundary';
+import { useTagFilter } from '@/hooks/place-list/useTagFilter';
 import { SortType } from '@/types/placeList';
 
 import TagList from '../tag/TagList';
@@ -13,19 +14,7 @@ import SortingDropdownButton from './SortingDropdownButton';
 
 export default function PlaceListDetailWrapper({ listId }: { listId: string }) {
   const [sortBy, setSortBy] = useState<SortType>('created_desc');
-  const [activeTagIds, setActiveTagIds] = useState<Set<string>>(new Set());
-
-  const handleToggleTag = (id: string) => {
-    setActiveTagIds((prev) => {
-      const updated = new Set(prev);
-      if (prev.has(id)) {
-        updated.delete(id);
-      } else {
-        updated.add(id);
-      }
-      return updated;
-    });
-  };
+  const { activeTagIds, handleToggleTag } = useTagFilter();
 
   return (
     <div className='flex flex-col gap-2.5 h-full'>

--- a/components/features/place-list/detail/PlaceListPlaces.tsx
+++ b/components/features/place-list/detail/PlaceListPlaces.tsx
@@ -62,15 +62,19 @@ export default function PlaceListPlaces({
 
   return (
     <>
-      {filteredPlaces.map((item) => (
-        <PlaceItem
-          key={item.id}
-          place={item}
-          listId={listId}
-          onClickItem={handleClickPlaceItem}
-          listTags={tags}
-        />
-      ))}
+      {filteredPlaces.length > 0 ? (
+        filteredPlaces.map((item) => (
+          <PlaceItem
+            key={item.id}
+            place={item}
+            listId={listId}
+            onClickItem={handleClickPlaceItem}
+            listTags={tags}
+          />
+        ))
+      ) : (
+        <EmptyState message='저장된 장소가 아직 없습니다.' />
+      )}
       {isOpenPlaceModal &&
         selectedId &&
         createPortal(

--- a/components/features/place-list/edit/EditPlace.tsx
+++ b/components/features/place-list/edit/EditPlace.tsx
@@ -1,15 +1,23 @@
 'use client';
 
+import { useMemo } from 'react';
+
 import { Icon } from '@/components/common/Icon';
-import { EditablePlace, EditablePlaceParams } from '@/types/placeList';
+import { EditablePlace, EditablePlaceParams, Tag } from '@/types/placeList';
+
+import PlaceTag from '../tag/PlaceTag';
 
 interface EditPlaceProps {
   place: EditablePlace;
-  onMemoChange: ({ id, memoContent }: EditablePlaceParams) => void;
+  onMemoChange: ({ id, memoContent }: Omit<EditablePlaceParams, 'tagIds'>) => void;
   onDeletePlace: (placeName: string, placeId: string) => void;
+  listTags: Tag[];
+  onToggleTag: (placeId: string, tagId: string) => void;
 }
 
-export default function EditPlace({ place, onMemoChange, onDeletePlace }: EditPlaceProps) {
+export default function EditPlace({ place, onMemoChange, onDeletePlace, listTags, onToggleTag }: EditPlaceProps) {
+  const selectedIds = useMemo(() => new Set(place.tagIds), [place.tagIds]);
+
   return (
     <div className='flex flex-col w-full border border-brand-gray-300 rounded-sm p-3 gap-2.5'>
       <div className='flex justify-between items-center'>
@@ -21,12 +29,26 @@ export default function EditPlace({ place, onMemoChange, onDeletePlace }: EditPl
           onClick={() => onDeletePlace(place.customName, place.id)}
         />
       </div>
+
       <textarea
         placeholder='메모 추가'
         value={place.memoContent ?? ''}
         className='bg-brand-gray-100 min-h-16 text-typo-base px-3 py-2 text-brand-gray-600 border border-brand-gray-200 outline-none rounded-sm w-full field-sizing-content resize-none hover:bg-brand-gray-200'
         onChange={(e) => onMemoChange({ id: place.id, memoContent: e.target.value })}
       />
+
+      {/* 태그 */}
+      <div className='flex gap-1 items-center overflow flex-wrap'>
+        {listTags.map((item) => (
+          <PlaceTag
+            key={item.id}
+            tag={item}
+            isEdit={true}
+            isSelected={selectedIds.has(item.id)}
+            onClick={() => onToggleTag(place.id, item.id)}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/features/place-list/edit/EditTagList.tsx
+++ b/components/features/place-list/edit/EditTagList.tsx
@@ -1,0 +1,51 @@
+import { Icon } from '@/components/common/Icon';
+import { useDragScroll } from '@/hooks/useDragScroll';
+import { useModalStore } from '@/lib/store/modalStore';
+import { Tag } from '@/types/placeList';
+
+import EditTagListItem from './EditTagListItem';
+
+interface EditTagListProps {
+  listId: string;
+  listTags: Tag[];
+  activeTagIds: Set<string>;
+  onToggleTag: (id: string) => void;
+}
+
+export default function EditTagList({ listId, listTags, activeTagIds, onToggleTag }: EditTagListProps) {
+  const { open } = useModalStore();
+  const { ref, ...dragHandler } = useDragScroll<HTMLDivElement>();
+
+  return (
+    <div
+      ref={ref}
+      {...dragHandler}
+      className='flex gap-2 overflow-x-scroll flex-1 items-center no-scrollbar'
+    >
+      <button
+        className='flex items-center gap-1 justify-center shrink-0 box-border px-3 py-1.5 rounded-sm cursor-pointer border border-brand-blue-700 text-brand-blue-700 hover:bg-brand-blue-700 hover:text-brand-gray-0'
+        onClick={() => open({ type: 'tag', props: { listId } })}
+      >
+        <Icon
+          name='Plus'
+          size={18}
+        />
+        새 태그
+      </button>
+      {listTags.map((item) => (
+        <EditTagListItem
+          key={item.id}
+          tag={item}
+          isActivated={activeTagIds.has(item.id)}
+          onClick={() => onToggleTag(item.id)}
+        />
+      ))}
+      <button
+        className='px-3 py-1.75 text-brand-blue-700 shrink-0 hover:bg-black/5 rounded-sm cursor-pointer'
+        onClick={() => open({ type: 'tag', props: { listId } })}
+      >
+        태그 수정
+      </button>
+    </div>
+  );
+}

--- a/components/features/place-list/edit/EditTagListItem.tsx
+++ b/components/features/place-list/edit/EditTagListItem.tsx
@@ -1,0 +1,26 @@
+import { Icon } from '@/components/common/Icon';
+import { Tag } from '@/types/placeList';
+
+interface EditTagListItemProps {
+  tag: Tag;
+  isActivated: boolean;
+  onClick: () => void;
+}
+
+export default function EditTagListItem({ tag, isActivated, onClick }: EditTagListItemProps) {
+  return (
+    <button
+      className={`flex items-center justify-center shrink-0 box-border px-3 py-1.5 rounded-sm cursor-pointer border gap-1 border-brand-blue-700 ${isActivated ? 'bg-brand-blue-700 text-brand-gray-0' : 'text-brand-blue-700 hover:bg-brand-gray-100'}`}
+      onClick={onClick}
+      data-drag-item
+    >
+      {isActivated && (
+        <Icon
+          name='Check'
+          size={18}
+        />
+      )}
+      {tag.name}
+    </button>
+  );
+}

--- a/components/features/place-list/edit/EditTagListItem.tsx
+++ b/components/features/place-list/edit/EditTagListItem.tsx
@@ -10,7 +10,7 @@ interface EditTagListItemProps {
 export default function EditTagListItem({ tag, isActivated, onClick }: EditTagListItemProps) {
   return (
     <button
-      className={`flex items-center justify-center shrink-0 box-border px-3 py-1.5 rounded-sm cursor-pointer border gap-1 border-brand-blue-700 ${isActivated ? 'bg-brand-blue-700 text-brand-gray-0' : 'text-brand-blue-700 hover:bg-brand-gray-100'}`}
+      className={`flex items-center justify-center shrink-0 box-border px-3 py-1.5 rounded-sm cursor-pointer border gap-1 ${isActivated ? 'bg-brand-gray-400 text-brand-gray-0 border-transparent' : 'text-brand-gray-500 hover:bg-brand-gray-100 border-brand-gray-300'}`}
       onClick={onClick}
       data-drag-item
     >

--- a/components/features/place-list/edit/EditTagListItem.tsx
+++ b/components/features/place-list/edit/EditTagListItem.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '@/components/common/Icon';
 import { Tag } from '@/types/placeList';
 
 interface EditTagListItemProps {
@@ -14,12 +13,6 @@ export default function EditTagListItem({ tag, isActivated, onClick }: EditTagLi
       onClick={onClick}
       data-drag-item
     >
-      {isActivated && (
-        <Icon
-          name='Check'
-          size={18}
-        />
-      )}
       {tag.name}
     </button>
   );

--- a/components/features/place-list/edit/PlaceListEditForm.tsx
+++ b/components/features/place-list/edit/PlaceListEditForm.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import EmptyState from '@/components/common/EmptyState';
 import { useConfirmDeletePlace } from '@/hooks/place-list/useConfirmDeletePlace';
+import { useGetPlaceListTags } from '@/hooks/place-list/useGetPlaceListTags';
+import { useTagFilter } from '@/hooks/place-list/useTagFilter';
 import { useUpdatePlaceList } from '@/hooks/place-list/useUpdatePlaceList';
 import { IconType } from '@/lib/emoji';
 import { EditablePlace, EditablePlaceParams, PlaceListDetail } from '@/types/placeList';
@@ -12,6 +14,7 @@ import { EditablePlace, EditablePlaceParams, PlaceListDetail } from '@/types/pla
 import EditableOverviewField, { PlaceListErrorType } from '../EditableOverviewField';
 
 import EditPlace from './EditPlace';
+import EditTagList from './EditTagList';
 
 interface PlaceListEditFormProps {
   listId: string;
@@ -31,14 +34,29 @@ export default function PlaceListEditForm({
   const [description, setDescription] = useState<string>(initialDetail.description);
   const [selectIcon, setSelectedIcon] = useState<IconType | undefined | null>(initialIcon);
   const [places, setPlaces] = useState<EditablePlace[]>(initialPlaces);
+
   const [error, setError] = useState<PlaceListErrorType | null>(null);
-  const { mutateAsync: updatePlaceList } = useUpdatePlaceList(listId);
+  const { mutateAsync: updatePlaceList, isPending } = useUpdatePlaceList(listId);
   const { confirmDeletePlaceList } = useConfirmDeletePlace(listId, (placeId) => {
     setPlaces((prev) => prev.filter((p) => p.id !== placeId));
   });
+  const { data: listTags } = useGetPlaceListTags(listId);
+  const { activeTagIds, handleToggleTag } = useTagFilter();
 
-  const handlePlaceMemoChange = ({ id, memoContent }: EditablePlaceParams) => {
+  const handlePlaceMemoChange = ({ id, memoContent }: Omit<EditablePlaceParams, 'tagIds'>) => {
     setPlaces((prev) => prev.map((p) => (p.id === id ? { ...p, memoContent } : p)));
+  };
+
+  const handleTogglePlaceTags = (placeId: string, tagId: string) => {
+    setPlaces((prev) =>
+      prev.map((place) => {
+        if (place.id !== placeId) return place;
+        const tagIds = place.tagIds.includes(tagId)
+          ? place.tagIds.filter((id) => id !== tagId)
+          : [...place.tagIds, tagId];
+        return { ...place, tagIds };
+      }),
+    );
   };
 
   const handleSave = async () => {
@@ -55,7 +73,14 @@ export default function PlaceListEditForm({
     // 값이 바뀐 장소 데이터만 전송
     const changedPlaces = places.filter((p) => {
       const original = initialPlaces.find((initial) => initial.id === p.id);
-      return original?.memoContent !== p.memoContent;
+      if (!original) return false;
+
+      // 메모가 바뀌었거나, 태그가 바뀌었으면 바뀐 장소로 간주
+      const memoChanged = original?.memoContent !== p.memoContent;
+      const tagChanged =
+        original.tagIds.length !== p.tagIds.length || !original.tagIds.every((id) => p.tagIds.includes(id));
+
+      return memoChanged || tagChanged;
     });
 
     try {
@@ -64,7 +89,7 @@ export default function PlaceListEditForm({
         newTitle: title,
         newIcon: (selectIcon && selectIcon?.emoji) || null,
         newDescription: (description && description.trim()) || null,
-        places: changedPlaces.map((p) => ({ id: p.id, memoContent: p.memoContent })),
+        places: changedPlaces.map((p) => ({ id: p.id, memoContent: p.memoContent, tagIds: p.tagIds })),
       });
       router.back();
     } catch (error) {
@@ -73,6 +98,11 @@ export default function PlaceListEditForm({
     }
   };
 
+  const filteredPlaces = useMemo(() => {
+    if (activeTagIds.size === 0) return places;
+    return places.filter((place) => place.tagIds.some((id) => activeTagIds.has(id)));
+  }, [activeTagIds, places]);
+
   return (
     <div className='flex flex-col h-full gap-6'>
       <header className='px-4 flex items-center flex-none'>
@@ -80,12 +110,13 @@ export default function PlaceListEditForm({
         <button
           onClick={handleSave}
           className='rounded-lg box-border font-light px-3 py-2 text-brand-gray-0 bg-brand-blue-700 flex items-center justify-center cursor-pointer hover:bg-brand-blue-800'
+          disabled={isPending}
         >
-          저장하기
+          {isPending ? '저장 중...' : '저장하기'}
         </button>
       </header>
 
-      <div className='px-4 pb-12 flex flex-col gap-6 overflow-y-auto'>
+      <div className='px-4 pb-12 flex flex-col gap-12 overflow-y-auto'>
         {/* 리스트 개요 */}
         <EditableOverviewField
           title={title}
@@ -97,15 +128,27 @@ export default function PlaceListEditForm({
           error={error}
         />
 
-        {/* 저장된 장소 */}
-        <div className='flex flex-col gap-4 mt-6'>
-          {places.length > 0 ? (
-            places.map((p) => (
+        <div className='flex flex-col gap-4'>
+          {/* 태그 */}
+          <div className='flex gap-2 text-typo-description items-center'>
+            <EditTagList
+              listId={listId}
+              listTags={listTags}
+              activeTagIds={activeTagIds}
+              onToggleTag={handleToggleTag}
+            />
+          </div>
+
+          {/* 저장된 장소 */}
+          {filteredPlaces.length > 0 ? (
+            filteredPlaces.map((p) => (
               <EditPlace
                 key={p.id}
                 place={p}
                 onMemoChange={handlePlaceMemoChange}
                 onDeletePlace={confirmDeletePlaceList}
+                listTags={listTags}
+                onToggleTag={handleTogglePlaceTags}
               />
             ))
           ) : (

--- a/components/features/place-list/tag/PlaceTag.tsx
+++ b/components/features/place-list/tag/PlaceTag.tsx
@@ -13,7 +13,7 @@ interface PlaceTagProps {
 export default function PlaceTag({ tag, onClick, isRounded = false, isEdit = false, isSelected }: PlaceTagProps) {
   return (
     <button
-      className={`shrink-0  flex gap-1 items-center justify-center box-border ${isRounded ? 'rounded-[28px]' : 'rounded-sm'} border ${isEdit && !isSelected ? 'border-brand-gray-300 text-brand-gray-500' : PLACE_TAG_COLOR[tag.color]} ${isEdit ? 'text-typo-description px-3 py-1.5' : 'text-typo-caption px-2 py-1'} hover:bg-brand-gray-50 cursor-pointer`}
+      className={`shrink-0  flex gap-1 items-center justify-center box-border ${isRounded ? 'rounded-[28px]' : 'rounded-sm'} border ${isEdit && !isSelected ? 'border-brand-gray-300 text-brand-gray-500 hover:bg-brand-gray-50' : PLACE_TAG_COLOR[tag.color]} ${isEdit ? 'text-typo-description px-3 py-1.5' : 'text-typo-caption px-2 py-1'} cursor-pointer`}
       onClick={onClick}
       aria-pressed={isEdit ? isSelected : undefined}
     >

--- a/hooks/place-list/useTagFilter.ts
+++ b/hooks/place-list/useTagFilter.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+export const useTagFilter = () => {
+  const [activeTagIds, setActiveTagIds] = useState<Set<string>>(new Set());
+
+  const handleToggleTag = (id: string) => {
+    setActiveTagIds((prev) => {
+      const updated = new Set(prev);
+      if (prev.has(id)) {
+        updated.delete(id);
+      } else {
+        updated.add(id);
+      }
+      return updated;
+    });
+  };
+
+  return {
+    activeTagIds,
+    handleToggleTag,
+  };
+};

--- a/types/placeList.ts
+++ b/types/placeList.ts
@@ -99,9 +99,8 @@ export interface GetPlacesParams {
   sortBy: SortType;
 }
 
-// 수정 페이지에서의 장소 - 추후 태그 추가
-export type EditablePlace = Pick<Place, 'id' | 'memoContent' | 'customName'>;
-export type EditablePlaceParams = Pick<EditablePlace, 'id' | 'memoContent'>;
+export type EditablePlace = Pick<Place, 'id' | 'memoContent' | 'customName'> & { tagIds: string[] };
+export type EditablePlaceParams = Pick<EditablePlace, 'id' | 'memoContent' | 'tagIds'>;
 
 // 장소 리스트 전체 편집 파라미터
 export interface UpdatePlaceListParams {


### PR DESCRIPTION
## 🛠️ 과제 요약

- 리스트 전체 편집에 태그 수정 기능 추가
- 태그 클릭 시 장소 필터링 기능 추가

<img width="700" alt="스크린샷 2026-09-07 오전 1 06 30" src="https://github.com/user-attachments/assets/d7e46b29-b9d2-468a-b6fb-4cda6444541a" /><br/>

## 📝 요구 사항과 구현 내용

#### 1️⃣ 리스트 전체 편집 시 태그 수정 기능 추가
- update_place_list rpc 수정
  - 클라이언트에서 p_places 배열의 각 장소 객체에 태그 변경이 있는 경우에만 tagIds(최종 연결될 태그 id 배열)를 포함시켜 보내도록 설정. 이 키가 없으면 장소는 태그를 건드리지 않고 기존 연결을 그대로 유지
  - 각 장소의 최종 tagIds와 기존 연결을 비교해서 없어진 것은 삭제하고, 새로 추가된 것만 삽입
- 태그 필터링 기능을 추가함에 따라 '새 태그' 버튼과 UI를 맞추는 게 좋을 것 같아서 디자인을 통일 
- 리스트 관리 페이지에서 사용하는 태그 리스트는 리스트 페이지와 요구사항이 달라질 수 있을 것 같아서 별도 컴포넌트를 생성해서 구현

#### 2️⃣ 리스트 페이지에 필터링 결과가 없을 때 문구 추가
<img width="300" alt="스크린샷 2026-09-07 오전 1 12 12" src="https://github.com/user-attachments/assets/4ef6abe1-8df1-416d-99a0-514adb5ad26f" />

#### 3️⃣ 태그 필터링 로직 재활용을 위해 훅으로 분리(`useTagFilter.ts`)
- id 기반으로 활성화된 태그를 확인하는 로직이 동일해서 훅으로 분리 적용

## 🔗 연관된 이슈
- close #160

